### PR TITLE
SSUT-86: Regenerate CarriersEORI page

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,18 @@
 
 This is a placeholder README.md for a new repository
 
+## Creating new pages
+
+A number of giter8 scaffolds are provided to help create new pages easily. These generate all the new classes you should
+need to have a working page, form, etc., depending on the type of page you're creating, and also creates a migration script
+which you can run to do the extra work of modifying files needed to add new pages, e.g. adding your new routes, setting
+some placeholder messages, adding page definitions to test generator utils, etc.
+
+You can add a new page by running `sbt 'g8Scaffold stringPage'`, for example, filling out the values you're prompted for,
+and then running `./migrate.sh` to run the generated migration script as well.
+
+You can see the different types of supported pages in the `.g8` directory.
+
 ## Running tests in Intellij
 In order to run the tests in Intellij, you should add the following to your test run configurations under "VM Options":
 ```

--- a/app/controllers/CarriersEORIController.scala
+++ b/app/controllers/CarriersEORIController.scala
@@ -18,7 +18,9 @@ package controllers
 
 import controllers.actions._
 import forms.CarriersEORIFormProvider
+import javax.inject.Inject
 import models.{LocalReferenceNumber, Mode}
+import models.GbEori._
 import pages.CarriersEORIPage
 import play.api.i18n.{I18nSupport, MessagesApi}
 import play.api.mvc.{Action, AnyContent, MessagesControllerComponents}
@@ -26,19 +28,18 @@ import repositories.SessionRepository
 import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendBaseController
 import views.html.CarriersEORIView
 
-import javax.inject.Inject
 import scala.concurrent.{ExecutionContext, Future}
 
 class CarriersEORIController @Inject()(
-                                        override val messagesApi: MessagesApi,
-                                        sessionRepository: SessionRepository,
-                                        identify: IdentifierAction,
-                                        getData: DataRetrievalActionProvider,
-                                        requireData: DataRequiredAction,
-                                        formProvider: CarriersEORIFormProvider,
-                                        val controllerComponents: MessagesControllerComponents,
-                                        view: CarriersEORIView
-                                    )(implicit ec: ExecutionContext) extends FrontendBaseController with I18nSupport {
+  override val messagesApi: MessagesApi,
+  sessionRepository: SessionRepository,
+  identify: IdentifierAction,
+  getData: DataRetrievalActionProvider,
+  requireData: DataRequiredAction,
+  formProvider: CarriersEORIFormProvider,
+  val controllerComponents: MessagesControllerComponents,
+  view: CarriersEORIView
+)(implicit ec: ExecutionContext) extends FrontendBaseController with I18nSupport {
 
   val form = formProvider()
 

--- a/app/forms/CarriersEORIFormProvider.scala
+++ b/app/forms/CarriersEORIFormProvider.scala
@@ -20,12 +20,8 @@ import javax.inject.Inject
 
 import forms.mappings.Mappings
 import play.api.data.Form
+import models.GbEori
 
 class CarriersEORIFormProvider @Inject() extends Mappings {
-
-  def apply(): Form[String] =
-    Form(
-      "value" -> text("carriersEORI.error.required")
-        .verifying(maxLength(100, "carriersEORI.error.length"))
-    )
+  def apply(): Form[GbEori] = Form("value" -> gbEori("carriersEORI.error.required"))
 }

--- a/app/forms/mappings/Mappings.scala
+++ b/app/forms/mappings/Mappings.scala
@@ -19,12 +19,21 @@ package forms.mappings
 import java.time.{LocalDate, LocalTime}
 import play.api.data.FieldMapping
 import play.api.data.Forms.of
-import models.Enumerable
+import models.{Enumerable, GbEori}
 
 trait Mappings extends Formatters with Constraints {
 
   protected def text(errorKey: String = "error.required", args: Seq[String] = Seq.empty): FieldMapping[String] =
     of(stringFormatter(errorKey, args))
+
+  protected def gbEori(
+    errorKey: String = "error.required",
+    lengthKey: String = "error.eori.length",
+    nonNumericKey: String = "error.eori.numeric",
+    args: Seq[String] = Nil
+  ): FieldMapping[GbEori] = {
+    of(gbEoriFormatter(errorKey, lengthKey, nonNumericKey, args))
+  }
 
   protected def int(requiredKey: String = "error.required",
                     wholeNumberKey: String = "error.wholeNumber",

--- a/app/models/GbEori.scala
+++ b/app/models/GbEori.scala
@@ -14,26 +14,19 @@
  * limitations under the License.
  */
 
-package forms
+package models
 
-import forms.behaviours.GbEoriFieldBehaviours
-import play.api.data.FormError
+import play.api.libs.json._
 
-class CarriersEORIFormProviderSpec extends GbEoriFieldBehaviours {
-  private val fieldName = "value"
-  private val requiredKey = "carriersEORI.error.required"
+/**
+ * Represents a GB EORI number
+ *
+ * A GB EORI is written as "GB" followed by 12 or 15 numeric characters. Since this models
+ * a GB EORI specifically, we only record the numeric characters.
+ */
+class GbEori(val value: String) extends AnyVal
 
-  private val form = new CarriersEORIFormProvider()()
-
-
-  ".value" - {
-
-    behave like mandatoryField(
-      form,
-      fieldName,
-      requiredError = FormError(fieldName, requiredKey)
-    )
-
-    behave like gbEoriField(form, fieldName)
-  }
+object GbEori {
+  implicit val reads: Reads[GbEori] = Reads.StringReads.map { new GbEori(_) }
+  implicit val writes: Writes[GbEori] = Writes.StringWrites.contramap { _.value }
 }

--- a/app/pages/CarriersEORIPage.scala
+++ b/app/pages/CarriersEORIPage.scala
@@ -16,9 +16,11 @@
 
 package pages
 
+import models.GbEori
 import play.api.libs.json.JsPath
+import play.api.mvc.Call
 
-case object CarriersEORIPage extends QuestionPage[String] {
+case object CarriersEORIPage extends QuestionPage[GbEori] {
 
   override def path: JsPath = JsPath \ toString
 

--- a/app/viewmodels/checkAnswers/CarriersEORISummary.scala
+++ b/app/viewmodels/checkAnswers/CarriersEORISummary.scala
@@ -33,7 +33,7 @@ object CarriersEORISummary  {
 
         SummaryListRowViewModel(
           key     = "carriersEORI.checkYourAnswersLabel",
-          value   = ValueViewModel(HtmlFormat.escape(answer).toString),
+          value   = ValueViewModel(HtmlFormat.escape(answer.value).toString),
           actions = Seq(
             ActionItemViewModel("site.change", routes.CarriersEORIController.onPageLoad(CheckMode, answers.lrn).url)
               .withVisuallyHiddenText(messages("carriersEORI.change.hidden"))

--- a/app/views/CarriersEORIView.scala.html
+++ b/app/views/CarriersEORIView.scala.html
@@ -28,7 +28,7 @@
 
 @layout(pageTitle = title(form, messages("carriersEORI.title"))) {
 
-    @formHelper(action = routes.CarriersEORIController.onSubmit(mode, lrn), 'autoComplete -> "off") {
+    @formHelper(action = routes.CarriersEORIController.onSubmit(mode, lrn)) {
 
         @if(form.errors.nonEmpty) {
             @govukErrorSummary(ErrorSummaryViewModel(form))
@@ -37,9 +37,10 @@
         @govukInput(
             InputViewModel(
                 field = form("value"),
-                label = LabelViewModel(messages("carriersEORI.heading")).asPageHeading()
+                label = LabelViewModel(messages("carriersEORI.heading")).asPageHeading(),
             )
             .withWidth(Full)
+            .withPrefix(PrefixOrSuffix(content = Text("GB")))
         )
 
         @govukButton(

--- a/conf/messages.en
+++ b/conf/messages.en
@@ -42,6 +42,8 @@ error.number = Please enter a valid number
 error.required = Please enter a value
 error.summary.title = There is a problem
 error.prefix = Error:
+error.eori.length = GB EORI must be 12 or 15 characters in length
+error.eori.numeric = GB EORI must contain only numbers
 
 index.title = Safety and Security
 index.heading = Safety and Security
@@ -125,7 +127,6 @@ carriersEORI.title = What is the GB EORI number of the carrier?
 carriersEORI.heading = What is the GB EORI number of the carrier?
 carriersEORI.checkYourAnswersLabel = GB EORI number
 carriersEORI.error.required = Enter the GB EORI number of the carrier
-carriersEORI.error.length = EORI number must be 100 characters or less
 carriersEORI.change.hidden = the GB EORI number of the carrier
 
 arrivalDateAndTime.title = When is the consignment due to arrive in Great Britain?

--- a/migrations/applied_migrations/CarriersEORI.sh
+++ b/migrations/applied_migrations/CarriersEORI.sh
@@ -32,7 +32,7 @@ awk '/trait UserAnswersEntryGenerators/ {\
     print "        value <- arbitrary[String].suchThat(_.nonEmpty).map(Json.toJson(_))";\
     print "      } yield (page, value)";\
     print "    }";\
-    next }1' ../test/generators/UserAnswersEntryGenerators.scala > tmp && mv tmp ../test/generators/UserAnswersEntryGenerators.scala
+    next }1' ../test-utils/generators/UserAnswersEntryGenerators.scala > tmp && mv tmp ../test-utils/generators/UserAnswersEntryGenerators.scala
 
 echo "Adding to PageGenerators"
 awk '/trait PageGenerators/ {\
@@ -40,12 +40,12 @@ awk '/trait PageGenerators/ {\
     print "";\
     print "  implicit lazy val arbitraryCarriersEORIPage: Arbitrary[CarriersEORIPage.type] =";\
     print "    Arbitrary(CarriersEORIPage)";\
-    next }1' ../test/generators/PageGenerators.scala > tmp && mv tmp ../test/generators/PageGenerators.scala
+    next }1' ../test-utils/generators/PageGenerators.scala > tmp && mv tmp ../test-utils/generators/PageGenerators.scala
 
 echo "Adding to UserAnswersGenerator"
 awk '/val generators/ {\
     print;\
     print "    arbitrary[(CarriersEORIPage.type, JsValue)] ::";\
-    next }1' ../test/generators/UserAnswersGenerator.scala > tmp && mv tmp ../test/generators/UserAnswersGenerator.scala
+    next }1' ../test-utils/generators/UserAnswersGenerator.scala > tmp && mv tmp ../test-utils/generators/UserAnswersGenerator.scala
 
 echo "Migration CarriersEORI completed"

--- a/test-utils/generators/ModelGenerators.scala
+++ b/test-utils/generators/ModelGenerators.scala
@@ -130,4 +130,9 @@ trait ModelGenerators {
     Arbitrary {
       Gen.oneOf(LodgingPersonType.values.toSeq)
     }
+
+  implicit lazy val arbitraryGbEori: Arbitrary[GbEori] =
+    Arbitrary {
+      Gen.listOfN(12, Gen.numChar).map { content: List[Char] => new GbEori(content.mkString) }
+    }
 }

--- a/test-utils/generators/PageGenerators.scala
+++ b/test-utils/generators/PageGenerators.scala
@@ -21,7 +21,6 @@ import org.scalacheck.Arbitrary
 import pages._
 
 trait PageGenerators {
-
   implicit lazy val arbitraryCarrierPaymentMethodPage: Arbitrary[CarrierPaymentMethodPage] =
     Arbitrary(CarrierPaymentMethodPage(Index(0)))
 

--- a/test-utils/generators/UserAnswersEntryGenerators.scala
+++ b/test-utils/generators/UserAnswersEntryGenerators.scala
@@ -23,7 +23,6 @@ import pages._
 import play.api.libs.json.{JsValue, Json}
 
 trait UserAnswersEntryGenerators extends PageGenerators with ModelGenerators {
-
   implicit lazy val arbitraryCarrierPaymentMethodUserAnswersEntry: Arbitrary[(CarrierPaymentMethodPage, JsValue)] =
     Arbitrary {
       for {

--- a/test/controllers/CarriersEORIControllerSpec.scala
+++ b/test/controllers/CarriersEORIControllerSpec.scala
@@ -18,7 +18,7 @@ package controllers
 
 import base.SpecBase
 import forms.CarriersEORIFormProvider
-import models.NormalMode
+import models.{GbEori, NormalMode}
 import org.mockito.ArgumentMatchers.{any, eq => eqTo}
 import org.mockito.Mockito.{times, verify, when}
 import org.scalatestplus.mockito.MockitoSugar
@@ -33,10 +33,11 @@ import scala.concurrent.Future
 
 class CarriersEORIControllerSpec extends SpecBase with MockitoSugar {
 
-  val formProvider = new CarriersEORIFormProvider()
-  val form = formProvider()
+  private val formProvider = new CarriersEORIFormProvider()
+  private val form = formProvider()
 
-  lazy val carriersEORIRoute = routes.CarriersEORIController.onPageLoad(NormalMode, lrn).url
+  private lazy val carriersEORIRoute = routes.CarriersEORIController.onPageLoad(NormalMode, lrn).url
+  private val eori = new GbEori("123456789000")
 
   "CarriersEORI Controller" - {
 
@@ -58,7 +59,7 @@ class CarriersEORIControllerSpec extends SpecBase with MockitoSugar {
 
     "must populate the view correctly on a GET when the question has previously been answered" in {
 
-      val userAnswers = emptyUserAnswers.set(CarriersEORIPage, "answer").success.value
+      val userAnswers = emptyUserAnswers.set(CarriersEORIPage, eori).success.value
 
       val application = applicationBuilder(userAnswers = Some(userAnswers)).build()
 
@@ -70,7 +71,7 @@ class CarriersEORIControllerSpec extends SpecBase with MockitoSugar {
         val result = route(application, request).value
 
         status(result) mustEqual OK
-        contentAsString(result) mustEqual view(form.fill("answer"), NormalMode, lrn)(request, messages(application)).toString
+        contentAsString(result) mustEqual view(form.fill(eori), NormalMode, lrn)(request, messages(application)).toString
       }
     }
 
@@ -88,10 +89,10 @@ class CarriersEORIControllerSpec extends SpecBase with MockitoSugar {
       running(application) {
         val request =
           FakeRequest(POST, carriersEORIRoute)
-            .withFormUrlEncodedBody(("value", "answer"))
+            .withFormUrlEncodedBody(("value", eori.value))
 
-        val result = route(application, request).value
-        val expectedAnswers = emptyUserAnswers.set(CarriersEORIPage, "answer").success.value
+        val result          = route(application, request).value
+        val expectedAnswers = emptyUserAnswers.set(CarriersEORIPage, eori).success.value
 
         status(result) mustEqual SEE_OTHER
         redirectLocation(result).value mustEqual CarriersEORIPage.navigate(NormalMode, expectedAnswers).url

--- a/test/forms/behaviours/GbEoriFieldBehaviours.scala
+++ b/test/forms/behaviours/GbEoriFieldBehaviours.scala
@@ -1,0 +1,85 @@
+/*
+ * Copyright 2022 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package forms.behaviours
+
+import models.GbEori
+import play.api.data.Form
+import org.scalacheck.Gen
+
+trait GbEoriFieldBehaviours extends FieldBehaviours {
+  private def expectValid(value: String, form: Form[GbEori], fieldName: String): Unit = {
+    // Expected value has all non-numeric characters removed
+    val expectedValue = value.filter { c => ('0' to '9').contains(c) }
+    val boundForm = form.bind(Map(fieldName -> value))
+
+    boundForm.errors mustBe empty
+    boundForm.get.value mustBe expectedValue
+  }
+
+  private def expectInvalid(value: String, form: Form[GbEori], fieldName: String): Unit = {
+    val boundForm = form.bind(Map(fieldName -> value))
+    boundForm.errors must not be empty
+  }
+
+  def gbEoriField(form: Form[GbEori], fieldName: String): Unit = {
+    "bind valid GB EORI" in {
+      // Be permissive with several possible human readable formats
+      val validEntries = Seq(
+        "GB 123 456 789 000",
+        "GB 123 456 789 000 000",
+        "GB123456789000",
+        "123 456 789 000",
+        "123456789000",
+      )
+
+      // Generate some more variations
+      val validEntriesGen = for {
+        prefix <- Gen.oneOf("", " GB", "GB", "GB ")
+        len <- Gen.oneOf(12, 15)
+        suffix <- Gen.listOfN(len, Gen.numChar)
+      } yield {
+        s"$prefix${suffix.mkString}"
+      }
+
+      forAll(validEntriesGen) { s => expectValid(s, form, fieldName) }
+      validEntries.foreach { s => expectValid(s, form, fieldName) }
+    }
+
+    "must not bind GB EORI with invalid prefixes" in {
+      val entries = for {
+        prefix <- Gen.oneOf("DE", "FR", "GG", "XX", "FOOOOO")
+        len <- Gen.oneOf(12, 15)
+        suffix <- Gen.listOfN(len, Gen.numChar)
+      } yield {
+        s"$prefix${suffix.mkString}"
+      }
+
+      forAll(entries) { s => expectInvalid(s, form, fieldName) }
+    }
+
+    "must not bind GB EORI with invalid length" in {
+      val entries = for {
+        prefix <- Gen.oneOf("", "GB")
+        len <- Gen.oneOf(10, 11, 13, 14, 16, 17, 18)
+        suffix <- Gen.listOfN(len, Gen.numChar)
+      } yield {
+        s"$prefix${suffix.mkString}"
+      }
+      forAll(entries) { s => expectInvalid(s, form, fieldName) }
+    }
+  }
+}

--- a/test/pages/CarriersEORIPageSpec.scala
+++ b/test/pages/CarriersEORIPageSpec.scala
@@ -18,7 +18,7 @@ package pages
 
 import base.SpecBase
 import controllers.routes
-import models.{CheckMode, NormalMode}
+import models.{CheckMode, GbEori, NormalMode}
 import pages.behaviours.PageBehaviours
 
 
@@ -26,11 +26,11 @@ class CarriersEORIPageSpec extends SpecBase with PageBehaviours {
 
   "CarriersEORIPage" - {
 
-    beRetrievable[String](CarriersEORIPage)
+    beRetrievable[GbEori](CarriersEORIPage)
 
-    beSettable[String](CarriersEORIPage)
+    beSettable[GbEori](CarriersEORIPage)
 
-    beRemovable[String](CarriersEORIPage)
+    beRemovable[GbEori](CarriersEORIPage)
 
     "must navigate in Normal Mode" - {
 


### PR DESCRIPTION
Remove the existing classes associated with this page and recreate it
with the scaffolding tools

Modify the form type to accept a GbEori type instead of String, and add
formatters to handle validating a GbEori:
  - must be 12 or 15 numbers
  - may include a GB prefix and arbitrary spaces, which will be removed

Add generic gbEori field type for forms which binds this new type

Add arbitrary gbEori field behaviour which can be reused by other forms
collecting a GB EORI once they migrate to this new field type.