### PR TITLE
SSUT-223: Add initial completion models/extractors

### DIFF
--- a/app/extractors/ConsignorIdentityExtractor.scala
+++ b/app/extractors/ConsignorIdentityExtractor.scala
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2022 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package extractors
+
+import cats.implicits._
+
+import extractors.ValidationError._
+import models.{ConsignorIdentity => ConsignorIdentityAnswer, Index, UserAnswers}
+import models.completion.answers.ConsignorIdentity
+import pages.consignors._
+
+class ConsignorIdentityExtractor(itemIndex: Index)(
+  override protected implicit val answers: UserAnswers
+) extends Extractor[ConsignorIdentity] {
+
+  private def extractByEori(): ValidationResult[ConsignorIdentity] = {
+    requireAnswer(ConsignorEORIPage(itemIndex)) map { ConsignorIdentity.ByEori(_) }
+  }
+
+  private def extractByAddress(): ValidationResult[ConsignorIdentity] = {
+    val name = requireAnswer(ConsignorNamePage(itemIndex))
+    val addr = requireAnswer(ConsignorAddressPage(itemIndex))
+
+    (name, addr).mapN(ConsignorIdentity.ByAddress)
+  }
+
+  override def extract(): ValidationResult[ConsignorIdentity] = {
+    val page = ConsignorIdentityPage(itemIndex)
+
+    answers.get(page) map {
+      case ConsignorIdentityAnswer.GBEORI => extractByEori()
+      case ConsignorIdentityAnswer.NameAddress => extractByAddress()
+    } getOrElse {
+      MissingField(page).invalidNec
+    }
+  }
+}

--- a/app/extractors/Extractor.scala
+++ b/app/extractors/Extractor.scala
@@ -14,12 +14,15 @@
  * limitations under the License.
  */
 
-package models
+package extractors
 
-import play.api.libs.json.Json
+import models.UserAnswers
 
-case class Address(streetAndNumber: String, city: String, postCode: String, country: Country)
+/**
+ * Extract a generic set of answers from the user answers
+ */
+trait Extractor[T] extends Extractors {
+  protected implicit def answers: UserAnswers
 
-object Address {
-  implicit val format = Json.format[Address]
+  def extract(): ValidationResult[T]
 }

--- a/app/extractors/Extractors.scala
+++ b/app/extractors/Extractors.scala
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2022 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package extractors
+
+import cats.data._
+import cats.implicits._
+import play.api.libs.json.Reads
+
+import models.UserAnswers
+import pages.QuestionPage
+
+/**
+ * Extractor DSL to neatly handle extracting answers in common patterns
+ */
+trait Extractors {
+  type ValidationResult[A] = ValidatedNec[ValidationError, A]
+
+  def requireAnswer[T : Reads](page: QuestionPage[T])(
+    implicit answers: UserAnswers
+  ): ValidationResult[T] = {
+    Validated.fromOption(answers.get(page), ValidationError.MissingField(page)).toValidatedNec
+  }
+
+  /**
+   * Get the answer to a question guarded by a "can you provide..." page
+   *
+   * This enforces the following rules:
+   *  - If they answered yes to `canProvidePage`, the answer must be provided
+   *  - If they answered no to `canProvidePage`, we'll return None
+   *  - If they didn't answer `canProvidePage`, we'll error as that field is missing
+   *
+   * @param canProvidePage The question page asking if the field is being provided
+   * @param answerPage The question page providing the answer
+   */
+  def getAnswer[T : Reads](canProvidePage: QuestionPage[Boolean], answerPage: QuestionPage[T])(
+    implicit answers: UserAnswers
+  ): ValidationResult[Option[T]] = {
+    answers.get(canProvidePage) map {
+      case true => requireAnswer[T](answerPage) map { Some(_) }
+      case _ => None.validNec
+    } getOrElse ValidationError.MissingField(canProvidePage).invalidNec
+  }
+}
+
+object Extractors extends Extractors

--- a/app/extractors/PredecExtractor.scala
+++ b/app/extractors/PredecExtractor.scala
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2022 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package extractors
+
+import cats.implicits._
+
+import models.{LocalReferenceNumber, ProvideGrossWeight, UserAnswers}
+import models.completion.answers.Predec
+import pages.{TotalGrossWeightPage, TransportModePage}
+import pages.preDeclaration._
+
+class PredecExtractor(
+  override protected implicit val answers: UserAnswers
+) extends Extractor[Predec] {
+
+  private def extractTotalMass(): ValidationResult[Option[BigDecimal]] = {
+    // TODO: Could be DRYer as it's similar to getAnswer?
+    answers.get(ProvideGrossWeightPage) map {
+      case ProvideGrossWeight.Overall => requireAnswer(TotalGrossWeightPage) map { Some(_) }
+      case ProvideGrossWeight.PerItem => None.validNec
+    } getOrElse ValidationError.MissingField(ProvideGrossWeightPage).invalidNec
+  }
+
+  override def extract(): ValidationResult[Predec] = {
+    val lrn: ValidationResult[LocalReferenceNumber] = answers.lrn.validNec
+    val location = requireAnswer(DeclarationPlacePage)
+    val crn = getAnswer(OverallCrnKnownPage, OverallCrnPage)
+    val totalMass = extractTotalMass()
+    val transportMode = requireAnswer(TransportModePage)
+
+    (lrn, location, crn, totalMass, transportMode).mapN(Predec)
+  }
+}

--- a/app/extractors/ValidationError.scala
+++ b/app/extractors/ValidationError.scala
@@ -14,12 +14,18 @@
  * limitations under the License.
  */
 
-package models
+package extractors
 
-import play.api.libs.json.Json
+import pages.QuestionPage
 
-case class Address(streetAndNumber: String, city: String, postCode: String, country: Country)
+sealed trait ValidationError {
+  val message: String
 
-object Address {
-  implicit val format = Json.format[Address]
+  override def toString: String = message
+}
+
+object ValidationError {
+  case class MissingField[T](page: QuestionPage[T]) extends ValidationError {
+    override val message: String = s"Field $page is missing!"
+  }
 }

--- a/app/models/completion/answers/ConsignorIdentity.scala
+++ b/app/models/completion/answers/ConsignorIdentity.scala
@@ -14,12 +14,13 @@
  * limitations under the License.
  */
 
-package models
+package models.completion.answers
 
-import play.api.libs.json.Json
+import models.{Address, GbEori}
 
-case class Address(streetAndNumber: String, city: String, postCode: String, country: Country)
+sealed trait ConsignorIdentity
 
-object Address {
-  implicit val format = Json.format[Address]
+object ConsignorIdentity {
+  case class ByEori(eori: GbEori) extends ConsignorIdentity
+  case class ByAddress(name: String, address: Address) extends ConsignorIdentity
 }

--- a/app/models/completion/answers/Predec.scala
+++ b/app/models/completion/answers/Predec.scala
@@ -14,12 +14,17 @@
  * limitations under the License.
  */
 
-package models
+package models.completion.answers
 
-import play.api.libs.json.Json
+import models.{LocalReferenceNumber, TransportMode}
 
-case class Address(streetAndNumber: String, city: String, postCode: String, country: Country)
-
-object Address {
-  implicit val format = Json.format[Address]
-}
+/**
+ * Models the answers given for a completed predeclaration section
+ */
+case class Predec(
+  lrn: LocalReferenceNumber,
+  location: String,
+  crn: Option[String],
+  totalMass: Option[BigDecimal],
+  transport: TransportMode
+)

--- a/project/AppDependencies.scala
+++ b/project/AppDependencies.scala
@@ -9,7 +9,8 @@ object AppDependencies {
     "uk.gov.hmrc" %% "play-conditional-form-mapping" % "1.9.0-play-28",
     "uk.gov.hmrc" %% "bootstrap-frontend-play-28" % "5.18.0",
     "uk.gov.hmrc" %% "play-language" % "5.1.0-play-28",
-    "uk.gov.hmrc.mongo" %% "hmrc-mongo-play-28" % "0.59.0"
+    "uk.gov.hmrc.mongo" %% "hmrc-mongo-play-28" % "0.59.0",
+    "org.typelevel" %% "cats-core" % "2.3.0"
   )
 
   val test = Seq(
@@ -23,7 +24,8 @@ object AppDependencies {
     "org.mockito" %% "mockito-scala" % "1.16.42",
     "org.scalacheck" %% "scalacheck" % "1.15.4",
     "uk.gov.hmrc.mongo" %% "hmrc-mongo-test-play-27" % "0.59.0",
-    "com.vladsch.flexmark" % "flexmark-all" % "0.62.2"
+    "com.vladsch.flexmark" % "flexmark-all" % "0.62.2",
+    "com.ironcorelabs" %% "cats-scalatest" % "3.1.1"
   ).map(_ % "test, it")
 
   def apply(): Seq[ModuleID] = compile ++ test

--- a/test/base/SpecBase.scala
+++ b/test/base/SpecBase.scala
@@ -18,6 +18,7 @@ package base
 
 import java.time.{Clock, Instant, LocalDate, ZoneId}
 
+import cats.scalatest.ValidatedValues
 import controllers.actions._
 import generators.Generators
 import models.{GbEori, Index, LocalReferenceNumber, UserAnswers}
@@ -36,6 +37,7 @@ trait SpecBase
   with Matchers
   with TryValues
   with OptionValues
+  with ValidatedValues
   with ScalaFutures
   with IntegrationPatience
   with Generators {

--- a/test/extractors/ConsignorIdentityExtractorSpec.scala
+++ b/test/extractors/ConsignorIdentityExtractorSpec.scala
@@ -1,0 +1,131 @@
+/*
+ * Copyright 2022 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package extractors
+
+import cats.implicits._
+import org.scalacheck.Arbitrary.arbitrary
+
+import base.SpecBase
+import extractors.ValidationError._
+import models.{ConsignorIdentity => ConsignorIdentityAnswer, _}
+import models.completion.answers.ConsignorIdentity
+import pages.consignors._
+
+class ConsignorIdentityExtractorSpec extends SpecBase {
+  private val baseAnswers: UserAnswers = arbitrary[UserAnswers].sample.value
+  private val itemOne: Index = Index(1)
+  private val itemTwo: Index = Index(2)
+  private val itemThree: Index = Index(3)
+
+  private val name = "Test Name"
+  private val gb = Country("GB", "United Kingdom")
+  private val addr = Address("123 Test Address", "City", "POSTCODE", gb)
+
+  "The consignor identity extractor" - {
+    "should extract consignor EORI" in {
+      implicit val answers = {
+        baseAnswers
+          .set(ConsignorIdentityPage(itemOne), ConsignorIdentityAnswer.GBEORI).success.value
+          .set(ConsignorEORIPage(itemOne), eori).success.value
+      }
+
+      val expected = ConsignorIdentity.ByEori(eori)
+      val actual = new ConsignorIdentityExtractor(itemOne).extract().value
+
+      actual must be(expected)
+    }
+
+    "should extract consignor name / address" in {
+      implicit val answers = {
+        baseAnswers
+          .set(ConsignorIdentityPage(itemOne), ConsignorIdentityAnswer.NameAddress).success.value
+          .set(ConsignorNamePage(itemOne), name).success.value
+          .set(ConsignorAddressPage(itemOne), addr).success.value
+      }
+
+      val expected = ConsignorIdentity.ByAddress(name, addr)
+      val actual = new ConsignorIdentityExtractor(itemOne).extract().value
+
+      actual must be(expected)
+    }
+
+    "should extract separate consignor identities for different item numbers" in {
+      val eori1 = arbitrary[GbEori].sample.value
+      val eori2 = arbitrary[GbEori].sample.value
+
+      implicit val answers = {
+        baseAnswers
+          .set(ConsignorIdentityPage(itemOne), ConsignorIdentityAnswer.GBEORI).success.value
+          .set(ConsignorEORIPage(itemOne), eori1).success.value
+          .set(ConsignorIdentityPage(itemTwo), ConsignorIdentityAnswer.GBEORI).success.value
+          .set(ConsignorEORIPage(itemTwo), eori2).success.value
+          .set(ConsignorIdentityPage(itemThree), ConsignorIdentityAnswer.NameAddress).success.value
+          .set(ConsignorNamePage(itemThree), name).success.value
+          .set(ConsignorAddressPage(itemThree), addr).success.value
+      }
+
+      Seq(
+        itemOne -> ConsignorIdentity.ByEori(eori1),
+        itemTwo -> ConsignorIdentity.ByEori(eori2),
+        itemThree -> ConsignorIdentity.ByAddress(name, addr)
+      ) foreach { case (itemNum, expected) =>
+        val actual = new ConsignorIdentityExtractor(itemNum).extract().value
+        actual must be(expected)
+      }
+    }
+
+    "should fail if missing the answer to how we're identifying consignor" in {
+      implicit val answers = baseAnswers.remove(ConsignorIdentityPage(itemOne)).success.value
+
+      val expected = Seq(MissingField(ConsignorIdentityPage(itemOne)))
+      val actual = new ConsignorIdentityExtractor(itemOne).extract().invalidValue.toList
+
+      actual must contain theSameElementsAs(expected)
+    }
+
+    "should fail if missing consignor EORI" in {
+      implicit val answers = {
+        baseAnswers
+          .set(ConsignorIdentityPage(itemOne), ConsignorIdentityAnswer.GBEORI).success.value
+          .remove(ConsignorEORIPage(itemOne)).success.value
+      }
+
+      val expected = Seq(MissingField(ConsignorEORIPage(itemOne)))
+      val actual = new ConsignorIdentityExtractor(itemOne).extract().invalidValue.toList
+
+      actual must contain theSameElementsAs(expected)
+    }
+
+    "should fail if missing consignor name and/or address" in {
+      implicit val answers = {
+        baseAnswers
+          .set(ConsignorIdentityPage(itemOne), ConsignorIdentityAnswer.NameAddress).success.value
+          .remove(ConsignorNamePage(itemOne)).success.value
+          .remove(ConsignorAddressPage(itemOne)).success.value
+      }
+
+      val expected = Seq(
+        MissingField(ConsignorNamePage(itemOne)),
+        MissingField(ConsignorAddressPage(itemOne))
+      )
+      val actual = new ConsignorIdentityExtractor(itemOne).extract().invalidValue.toList
+
+      actual must contain theSameElementsAs(expected)
+    }
+  }
+}
+

--- a/test/extractors/PredecExtractorSpec.scala
+++ b/test/extractors/PredecExtractorSpec.scala
@@ -1,0 +1,123 @@
+/*
+ * Copyright 2022 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package extractors
+
+import cats.implicits._
+import org.scalacheck.Arbitrary.arbitrary
+
+import base.SpecBase
+import extractors.ValidationError._
+import models.{ProvideGrossWeight, TransportMode, UserAnswers}
+import models.completion.answers.Predec
+import pages.{TotalGrossWeightPage, TransportModePage}
+import pages.preDeclaration._
+
+class PredecExtractorSpec extends SpecBase {
+  private val location = "test-declaration-location"
+  private val crn = "TEST-CRN"
+  private val totalMass = 1000
+  private val transportMode = TransportMode.Road
+
+  private val validAnswers = {
+    arbitrary[UserAnswers].sample.value
+      .set(DeclarationPlacePage, location).success.value
+      .set(OverallCrnKnownPage, true).success.value
+      .set(OverallCrnPage, crn).success.value
+      .set(ProvideGrossWeightPage, ProvideGrossWeight.Overall).success.value
+      .set(TotalGrossWeightPage, BigDecimal.exact(totalMass)).success.value
+      .set(TransportModePage, transportMode).success.value
+  }
+
+  "The predeclaration extractor" - {
+    "should correctly extract a valid predeclaration" in {
+      implicit val answers = validAnswers
+
+      val expected = Predec(
+        lrn = validAnswers.lrn,
+        location = location,
+        crn = Some(crn),
+        totalMass = Some(totalMass),
+        transport = transportMode
+      )
+      val actual = new PredecExtractor().extract().value
+
+      actual must be(expected)
+    }
+
+    "should correctly extract when not answering optional questions" in {
+      implicit val answers = {
+        validAnswers
+          .set(OverallCrnKnownPage, false).success.value
+          .remove(OverallCrnPage).success.value
+          .set(ProvideGrossWeightPage, ProvideGrossWeight.PerItem).success.value
+          .remove(TotalGrossWeightPage).success.value
+      }
+
+      val expected = Predec(
+        lrn = validAnswers.lrn,
+        location = location,
+        crn = None,
+        totalMass = None,
+        transport = transportMode
+      )
+      val actual = new PredecExtractor().extract().value
+
+      actual must be(expected)
+    }
+
+    "should fail for any missing required fields" in {
+      implicit val answers = {
+        validAnswers
+          .remove(DeclarationPlacePage).success.value
+          .remove(OverallCrnKnownPage).success.value
+          .remove(OverallCrnPage).success.value
+          .remove(ProvideGrossWeightPage).success.value
+          .remove(TotalGrossWeightPage).success.value
+          .remove(TransportModePage).success.value
+      }
+
+      val expected = List(
+        MissingField(DeclarationPlacePage),
+        MissingField(OverallCrnKnownPage),
+        MissingField(ProvideGrossWeightPage),
+        MissingField(TransportModePage)
+      )
+      val actual = new PredecExtractor().extract().invalidValue.toList
+
+      actual must contain theSameElementsAs(expected)
+    }
+
+    "should fail if CRN known but not provided" in {
+      implicit val answers = validAnswers.remove(OverallCrnPage).success.value
+
+      val expected = List(MissingField(OverallCrnPage))
+      val actual = new PredecExtractor().extract().invalidValue.toList
+
+      actual must contain theSameElementsAs(expected)
+    }
+
+    "should fail if gross weight not fully provided" in {
+      implicit val answers = validAnswers.remove(TotalGrossWeightPage).success.value
+
+      val expected = List(MissingField(TotalGrossWeightPage))
+      val actual = new PredecExtractor().extract().invalidValue.toList
+
+      actual must contain theSameElementsAs(expected)
+    }
+
+  }
+}


### PR DESCRIPTION
Add models for completed answer sections for:
  - predeclaration section
  - consignor identity (per item)

Add an extractor API + a small DSL to help us extract data from answers
easily and collect errors as we go using cats.Validated