### PR TITLE
SSUT-344: Fix NationalityOfTransport nav

### DIFF
--- a/app/pages/transport/NationalityOfTransportPage.scala
+++ b/app/pages/transport/NationalityOfTransportPage.scala
@@ -19,6 +19,7 @@ package pages.transport
 import controllers.transport.{routes => transportRoutes}
 import controllers.routes
 import models.{Country, NormalMode, UserAnswers}
+import models.TransportMode._
 import pages.QuestionPage
 import play.api.libs.json.JsPath
 import play.api.mvc.Call
@@ -30,6 +31,21 @@ case object NationalityOfTransportPage extends QuestionPage[Country] {
   override def toString: String = "nationalityOfTransport"
 
   override protected def navigateInNormalMode(answers: UserAnswers): Call = {
-    transportRoutes.RoroUnaccompaniedIdentityController.onPageLoad(NormalMode, answers.lrn)
+    answers.get(TransportModePage) map {
+      case Air =>
+        transportRoutes.AirIdentityController.onPageLoad(NormalMode, answers.lrn)
+      case Maritime =>
+        transportRoutes.MaritimeIdentityController.onPageLoad(NormalMode, answers.lrn)
+      case Rail =>
+        transportRoutes.RailIdentityController.onPageLoad(NormalMode, answers.lrn)
+      case Road =>
+        transportRoutes.RoadIdentityController.onPageLoad(NormalMode, answers.lrn)
+      case RoroAccompanied =>
+        transportRoutes.RoroAccompaniedIdentityController.onPageLoad(NormalMode, answers.lrn)
+      case RoroUnaccompanied =>
+        transportRoutes.RoroUnaccompaniedIdentityController.onPageLoad(NormalMode, answers.lrn)
+    } getOrElse {
+      routes.JourneyRecoveryController.onPageLoad()
+    }
   }
 }

--- a/app/pages/transport/TransportModePage.scala
+++ b/app/pages/transport/TransportModePage.scala
@@ -41,7 +41,10 @@ case object TransportModePage extends QuestionPage[TransportMode] {
       case Some(Maritime) =>
         transportRoutes.MaritimeIdentityController.onPageLoad(NormalMode, answers.lrn)
 
-      case Some(_) =>
+      case Some(RoroAccompanied) | Some(RoroUnaccompanied) | Some(Road) =>
         transportRoutes.NationalityOfTransportController.onPageLoad(NormalMode, answers.lrn)
+
+      case None =>
+        routes.JourneyRecoveryController.onPageLoad()
     }
 }

--- a/test/pages/transport/NationalityOfTransportPageSpec.scala
+++ b/test/pages/transport/NationalityOfTransportPageSpec.scala
@@ -19,11 +19,11 @@ package pages.transport
 import base.SpecBase
 import controllers.transport.{routes => transportRoutes}
 import controllers.routes
-import models.{CheckMode, Country, NormalMode}
+import models.{CheckMode, Country, NormalMode, TransportMode}
+import models.TransportMode._
 import pages.behaviours.PageBehaviours
 
 class NationalityOfTransportPageSpec extends SpecBase with PageBehaviours {
-
   "NationalityOfTransportPage" - {
 
     beRetrievable[Country](NationalityOfTransportPage)
@@ -34,12 +34,64 @@ class NationalityOfTransportPageSpec extends SpecBase with PageBehaviours {
 
     "must navigate in Normal Mode" - {
 
-      "to Index" in {
+      "to Roro Unaccompanied Identity if transport mode is Roro Unaccompanied" in {
+        val answers = emptyUserAnswers.set(TransportModePage, RoroUnaccompanied).success.value
 
-        NationalityOfTransportPage.navigate(NormalMode, emptyUserAnswers)
+        NationalityOfTransportPage.navigate(NormalMode, answers)
           .mustEqual(
             transportRoutes.RoroUnaccompaniedIdentityController
-              .onPageLoad(NormalMode, emptyUserAnswers.lrn))
+              .onPageLoad(NormalMode, answers.lrn)
+          )
+      }
+
+      "to Roro Accompanied Identity if transport mode is Roro Accompanied" in {
+        val answers = emptyUserAnswers.set(TransportModePage, RoroAccompanied).success.value
+
+        NationalityOfTransportPage.navigate(NormalMode, answers)
+          .mustEqual(
+            transportRoutes.RoroAccompaniedIdentityController
+              .onPageLoad(NormalMode, answers.lrn)
+          )
+      }
+
+      "to Maritime Identity if transport mode is Maritime" in {
+        val answers = emptyUserAnswers.set(TransportModePage, Maritime).success.value
+
+        NationalityOfTransportPage.navigate(NormalMode, answers)
+          .mustEqual(
+            transportRoutes.MaritimeIdentityController
+              .onPageLoad(NormalMode, answers.lrn)
+          )
+      }
+
+      "to Rail Identity if transport mode is Rail" in {
+        val answers = emptyUserAnswers.set(TransportModePage, Rail).success.value
+
+        NationalityOfTransportPage.navigate(NormalMode, answers)
+          .mustEqual(
+            transportRoutes.RailIdentityController
+              .onPageLoad(NormalMode, answers.lrn)
+          )
+      }
+
+      "to Air Identity if transport mode is Air" in {
+        val answers = emptyUserAnswers.set(TransportModePage, Air).success.value
+
+        NationalityOfTransportPage.navigate(NormalMode, answers)
+          .mustEqual(
+            transportRoutes.AirIdentityController
+              .onPageLoad(NormalMode, answers.lrn)
+          )
+      }
+
+      "to Road Identity if transport mode is Road" in {
+        val answers = emptyUserAnswers.set(TransportModePage, Road).success.value
+
+        NationalityOfTransportPage.navigate(NormalMode, answers)
+          .mustEqual(
+            transportRoutes.RoadIdentityController
+              .onPageLoad(NormalMode, answers.lrn)
+          )
       }
     }
 


### PR DESCRIPTION
It should always redirect to the identity page for the selected mode of
transport; previously it was always going to unaccompanied roro.

While I'm here, fix a mistaken introduced to TransportModePage's nav
which weakened our guarantees for handling each type of transport mode
and introduced an inexhaustive match, instead explicitly sending the
user to journey recovery if the match fails.