### PR TITLE
SSUT-287/SSUT-283: Party models + serialisers

### DIFF
--- a/app/models/completion/downstream/Party.scala
+++ b/app/models/completion/downstream/Party.scala
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2022 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package models.completion.downstream
+
+import models.Address
+
+/**
+ * This identifies any party reported within the XML payload, by EORI or name + address
+ *
+ * This applies to several different parties, e.g. consignors, consignees, declaring person,
+ * notified party...
+ */
+sealed trait Party
+
+object Party {
+  case class ByEori(eori: String) extends Party
+  case class ByAddress(name: String, address: Address) extends Party
+}

--- a/app/serialisation/xml/PackagesFormats.scala
+++ b/app/serialisation/xml/PackagesFormats.scala
@@ -27,7 +27,7 @@ trait PackagesFormats extends CommonFormats {
   implicit val packageKindFormat = new StringFormat[KindOfPackage] {
     override def encode(packageKind: KindOfPackage): String = packageKind.code
     override def decode(s: String): KindOfPackage = {
-      KindOfPackage.standardKindsOfPackages.find { _.code == s }.getOrElse {
+      KindOfPackage.allKindsOfPackage.find { _.code == s }.getOrElse {
         throw new XmlDecodingException(s"Bad Package code: $s")
       }
     }

--- a/app/serialisation/xml/PartyFormats.scala
+++ b/app/serialisation/xml/PartyFormats.scala
@@ -1,0 +1,127 @@
+/*
+ * Copyright 2022 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package serialisation.xml
+
+import scala.xml.{Elem, NodeSeq, Null, Text, TopScope}
+
+import models.completion.downstream.Party
+import models.{Address, Country}
+import serialisation.xml.XmlImplicits._
+
+/**
+ * Formats related to identifying parties of interest in the declaration
+ */
+trait PartyFormats extends CommonFormats {
+  import PartyFormats.Fields
+
+  private def partyFmt(fields: PartyFormats.Fields): Format[Party] = new Format[Party] {
+    /**
+     * Convenience method to more easily create an XML element with a non-literal label
+     */
+    private def elem(label: String, content: String): Elem = Elem(
+      prefix = null,
+      label = label,
+      attributes = Null,
+      scope = TopScope,
+      minimizeEmpty = false,
+      Text(content)
+    )
+
+    override def encode(p: Party): NodeSeq = p match {
+      case Party.ByEori(eori) =>
+        elem(fields.eori, eori)
+      case Party.ByAddress(name, addr) =>
+        Seq(
+          elem(fields.name, name),
+          elem(fields.streetAndNumber, addr.streetAndNumber),
+          elem(fields.postCode, addr.postCode),
+          elem(fields.city, addr.city),
+          elem(fields.country, addr.country.toXmlString)
+        )
+    }
+
+    override def decode(data: NodeSeq): Party = {
+      (data \\ fields.eori).headOption map {
+        eori => Party.ByEori(eori.text)
+      } getOrElse {
+        Party.ByAddress(
+          (data \\ fields.name).text,
+          Address(
+            (data \\ fields.streetAndNumber).text,
+            (data \\ fields.city).text,
+            (data \\ fields.postCode).text,
+            (data \\ fields.country).text.parseXmlString[Country]
+          )
+        )
+      }
+    }
+  }
+
+  val goodsConsignorFormat = {
+    partyFmt(Fields("TINCO259", "NamCO27", "StrAndNumCO222", "CitCO224", "PosCodCO223", "CouCO225"))
+  }
+
+  val goodsConsigneeFormat = {
+    partyFmt(Fields("TINCE259", "NamCE27", "StrAndNumCE222", "CitCE224", "PosCodCE223", "CouCE225"))
+  }
+
+  val goodsNotifiedPartyFormat = {
+    partyFmt(
+      Fields(
+        "TINPRTNOT641",
+        "NamPRTNOT642",
+        "StrNumPRTNOT646",
+        "CtyPRTNOT643",
+        "PstCodPRTNOT644",
+        "CouCodGINOT647"
+      )
+    )
+  }
+
+  val lodgingPersonFormat = {
+    partyFmt(Fields("TINPLD1", "NamPLD1", "StrAndNumPLD1", "CitPLD1", "PosCodPLD1", "CouCodPLD1"))
+  }
+
+  val carrierFormat = {
+    partyFmt(
+      Fields(
+        "TINTRACARENT602",
+        "NamTRACARENT604",
+        "StrNumTRACARENT607",
+        "CtyTRACARENT603",
+        "PstCodTRACARENT606",
+        "CouCodTRACARENT605"
+      )
+    )
+  }
+}
+
+object PartyFormats extends PartyFormats {
+  /**
+   * Identifies the field names required to (de)serialise this party
+   *
+   * These fields vary depending on which party is being identified
+   */
+  private[xml] case class Fields(
+    eori: String,
+    name: String,
+    streetAndNumber: String,
+    city: String,
+    postCode: String,
+    country: String
+  )
+}

--- a/test/serialisation/xml/PartyFormatsSpec.scala
+++ b/test/serialisation/xml/PartyFormatsSpec.scala
@@ -1,0 +1,247 @@
+/*
+ * Copyright 2022 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package serialisation.xml
+
+import org.scalacheck.Arbitrary.arbitrary
+import org.scalacheck.Gen
+import org.scalatestplus.scalacheck.ScalaCheckPropertyChecks
+
+import base.SpecBase
+import models.{Address, Country}
+import models.completion.downstream.Party
+
+class PartyFormatsSpec
+  extends SpecBase
+  with ScalaCheckPropertyChecks
+  with PartyFormats
+  with XmlImplicits {
+
+  private val partyByEori: Gen[Party] = for {
+    country <- Gen.oneOf(Country.allCountries)
+    number <- Gen.numStr.map { _.take(12) }
+  } yield Party.ByEori(s"${country.code}$number")
+
+  private val partyByAddress: Gen[Party] = for {
+    name <- Gen.alphaStr.map { _.take(40) }
+    addr <- arbitrary[Address]
+  } yield Party.ByAddress(name, addr)
+
+  "The goods consignor format" - {
+    implicit val fmt: Format[Party] = goodsConsignorFormat
+
+    "identified by EORI" - {
+      "should serialise symmetrically" in {
+        forAll(partyByEori) { p => p.toXml.parseXml[Party] must be(p) }
+      }
+
+      "should serialise correctly to XML" in {
+        forAll(partyByEori) { p =>
+          val actual = p.toXml
+          val expected = <TINCO259>{p.asInstanceOf[Party.ByEori].eori}</TINCO259>
+          actual must contain theSameElementsInOrderAs(expected)
+        }
+      }
+    }
+
+    "identified by name and address" - {
+      "should serialise symmetrically" in {
+        forAll(partyByAddress) { p => p.toXml.parseXml[Party] must be(p) }
+      }
+
+      "should serialise correctly to XML" in {
+        forAll(partyByAddress) { p =>
+          val actual = p.toXml
+          val expected = {
+            val byAddr = p.asInstanceOf[Party.ByAddress]
+
+            <NamCO27>{byAddr.name}</NamCO27>
+            <StrAndNumCO222>{byAddr.address.streetAndNumber}</StrAndNumCO222>
+            <PosCodCO223>{byAddr.address.postCode}</PosCodCO223>
+            <CitCO224>{byAddr.address.city}</CitCO224>
+            <CouCO225>{byAddr.address.country.toXmlString}</CouCO225>
+          }
+
+          actual must contain theSameElementsInOrderAs(expected)
+        }
+      }
+    }
+  }
+
+  "The goods consignee format" - {
+    implicit val fmt = goodsConsigneeFormat
+
+    "identified by EORI" - {
+      "should serialise symmetrically" in {
+        forAll(partyByEori) { p => p.toXml.parseXml[Party] must be(p) }
+      }
+
+      "should serialise correctly to XML" in {
+        forAll(partyByEori) { p =>
+          val actual = p.toXml
+          val expected = <TINCE259>{p.asInstanceOf[Party.ByEori].eori}</TINCE259>
+          actual must contain theSameElementsAs(expected)
+        }
+      }
+    }
+
+    "identified by name and address" - {
+      "should serialise symmetrically" in {
+        forAll(partyByAddress) { p => p.toXml.parseXml[Party] must be(p) }
+      }
+
+      "should serialise correctly to XML" in {
+        forAll(partyByAddress) { p =>
+          val actual = p.toXml
+          val expected = {
+            val byAddr = p.asInstanceOf[Party.ByAddress]
+
+            <NamCE27>{byAddr.name}</NamCE27>
+            <StrAndNumCE222>{byAddr.address.streetAndNumber}</StrAndNumCE222>
+            <PosCodCE223>{byAddr.address.postCode}</PosCodCE223>
+            <CitCE224>{byAddr.address.city}</CitCE224>
+            <CouCE225>{byAddr.address.country.toXmlString}</CouCE225>
+          }
+
+          actual must contain theSameElementsInOrderAs(expected)
+        }
+      }
+    }
+  }
+
+  "The goods notified party format" - {
+    implicit val fmt = goodsNotifiedPartyFormat
+
+    "identified by EORI" - {
+      "should serialise symmetrically" in {
+        forAll(partyByEori) { p => p.toXml.parseXml[Party] must be(p) }
+      }
+
+      "should serialise correctly to XML" in {
+        forAll(partyByEori) { p =>
+          val actual = p.toXml
+          val expected = <TINPRTNOT641>{p.asInstanceOf[Party.ByEori].eori}</TINPRTNOT641>
+          actual must contain theSameElementsInOrderAs(expected)
+        }
+      }
+    }
+
+    "identified by name and address" - {
+      "should serialise symmetrically" in {
+        forAll(partyByAddress) { p => p.toXml.parseXml[Party] must be(p) }
+      }
+
+      "should serialise correctly to XML" in {
+        forAll(partyByAddress) { p =>
+          val actual = p.toXml
+          val expected = {
+            val byAddr = p.asInstanceOf[Party.ByAddress]
+
+            <NamPRTNOT642>{byAddr.name}</NamPRTNOT642>
+            <StrNumPRTNOT646>{byAddr.address.streetAndNumber}</StrNumPRTNOT646>
+            <PstCodPRTNOT644>{byAddr.address.postCode}</PstCodPRTNOT644>
+            <CtyPRTNOT643>{byAddr.address.city}</CtyPRTNOT643>
+            <CouCodGINOT647>{byAddr.address.country.toXmlString}</CouCodGINOT647>
+          }
+
+          actual must contain theSameElementsInOrderAs(expected)
+        }
+      }
+    }
+  }
+
+  "The lodging person format" - {
+    implicit val fmt = lodgingPersonFormat
+
+    "identified by EORI" - {
+      "should serialise symmetrically" in {
+        forAll(partyByEori) { p => p.toXml.parseXml[Party] must be(p) }
+      }
+
+      "should serialise correctly to XML" in {
+        forAll(partyByEori) { p =>
+          val actual = p.toXml
+          val expected = <TINPLD1>{p.asInstanceOf[Party.ByEori].eori}</TINPLD1>
+          actual must contain theSameElementsInOrderAs(expected)
+        }
+      }
+    }
+
+    "identified by name and address" - {
+      "should serialise symmetrically" in {
+        forAll(partyByAddress) { p => p.toXml.parseXml[Party] must be(p) }
+      }
+
+      "should serialise correctly to XML" in {
+        forAll(partyByAddress) { p =>
+          val actual = p.toXml
+          val expected = {
+            val byAddr = p.asInstanceOf[Party.ByAddress]
+
+            <NamPLD1>{byAddr.name}</NamPLD1>
+            <StrAndNumPLD1>{byAddr.address.streetAndNumber}</StrAndNumPLD1>
+            <PosCodPLD1>{byAddr.address.postCode}</PosCodPLD1>
+            <CitPLD1>{byAddr.address.city}</CitPLD1>
+            <CouCodPLD1>{byAddr.address.country.toXmlString}</CouCodPLD1>
+          }
+
+          actual must contain theSameElementsInOrderAs(expected)
+        }
+      }
+    }
+  }
+
+  "The carrier format" - {
+    implicit val fmt = carrierFormat
+
+    "identified by EORI" - {
+      "should serialise symmetrically" in {
+        forAll(partyByEori) { p => p.toXml.parseXml[Party] must be(p) }
+      }
+
+      "should serialise correctly to XML" in {
+        forAll(partyByEori) { p =>
+          val actual = p.toXml
+          val expected = <TINTRACARENT602>{p.asInstanceOf[Party.ByEori].eori}</TINTRACARENT602>
+          actual must contain theSameElementsAs(expected)
+        }
+      }
+    }
+
+    "identified by name and address" - {
+      "should serialise symmetrically" in {
+        forAll(partyByAddress) { p => p.toXml.parseXml[Party] must be(p) }
+      }
+
+      "should serialise correctly to XML" in {
+        forAll(partyByAddress) { p =>
+          val actual = p.toXml
+          val expected = {
+            val byAddr = p.asInstanceOf[Party.ByAddress]
+
+            <NamTRACARENT604>{byAddr.name}</NamTRACARENT604>
+            <StrNumTRACARENT607>{byAddr.address.streetAndNumber}</StrNumTRACARENT607>
+            <PstCodTRACARENT606>{byAddr.address.postCode}</PstCodTRACARENT606>
+            <CtyTRACARENT603>{byAddr.address.city}</CtyTRACARENT603>
+            <CouCodTRACARENT605>{byAddr.address.country.toXmlString}</CouCodTRACARENT605>
+          }
+
+          actual must contain theSameElementsInOrderAs(expected)
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
All fields referring to a person/company are identified by either eori
or name + address, so we can use a single Party model in the XML to
refer to each of these parties.

These fields are serialised with different field names, though, so we
need to provide the correct set of field names for each party
serialised. Create a generic Party serialisation format which takes a
set of fields in order to achieve this in a DRY way.

WIP: Needs tests