### PR TITLE
SSUT-284: Good item XML model + formats

### DIFF
--- a/app/models/completion/downstream/DangerousGoodsCode.scala
+++ b/app/models/completion/downstream/DangerousGoodsCode.scala
@@ -1,0 +1,19 @@
+/*
+ * Copyright 2022 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package models.completion.downstream
+
+case class DangerousGoodsCode(code: String) extends AnyVal

--- a/app/models/completion/downstream/GoodsItem.scala
+++ b/app/models/completion/downstream/GoodsItem.scala
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2022 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package models.completion.downstream
+
+import models.{Container, Document, PaymentMethod}
+
+/**
+ * Represents a single goods item in the XML payload (GOOITEGDS)
+ */
+case class GoodsItem(
+  itemNumber: Int,
+  itemIdentity: GoodsItemIdentity,
+  grossMass: Option[BigDecimal],
+  paymentMethod: PaymentMethod,
+  dangerousGoodsCode: Option[DangerousGoodsCode],
+  placeOfLoading: LoadingPlace,
+  placeOfUnloading: LoadingPlace,
+  documents: List[Document],
+  consignor: Party,
+  consignee: Option[Party],
+  notifiedParty: Option[Party],
+  containers: List[Container],
+  packages: List[Package],
+  specialMentions: List[SpecialMention]
+)

--- a/app/models/completion/downstream/GoodsItemIdentity.scala
+++ b/app/models/completion/downstream/GoodsItemIdentity.scala
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2022 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package models.completion.downstream
+
+/**
+ * Identify a goods item category by either providing a commodity code or a freetext description
+ */
+sealed trait GoodsItemIdentity
+
+object GoodsItemIdentity {
+  case class ByCommodityCode(code: String) extends GoodsItemIdentity
+  case class WithDescription(desc: String) extends GoodsItemIdentity
+}

--- a/app/models/completion/downstream/LoadingPlace.scala
+++ b/app/models/completion/downstream/LoadingPlace.scala
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2022 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package models.completion.downstream
+
+import models.Country
+
+/**
+ * A place where good are loaded or unloaded
+ *
+ * Represents both the "place of loading" and "place of unloading" and is a simplified version of
+ * the individual models found in the journey
+ */
+case class LoadingPlace(country: Country, desc: String)

--- a/app/models/completion/downstream/Package.scala
+++ b/app/models/completion/downstream/Package.scala
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2022 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package models.completion.downstream
+
+import play.api.libs.json._
+
+import models.KindOfPackage
+
+/**
+ * Represents each package entry in the XML payload, i.e. "PACGS2" in the goods items
+ */
+case class Package(
+  kindPackage: KindOfPackage,
+  numPackages: Option[Int],
+  numPieces: Option[Int],
+  mark: Option[String]
+)
+
+object Package {
+  implicit val format: OFormat[Package] = Json.format[Package]
+}

--- a/app/models/completion/downstream/SpecialMention.scala
+++ b/app/models/completion/downstream/SpecialMention.scala
@@ -16,19 +16,12 @@
 
 package models.completion.downstream
 
-import play.api.libs.json._
-
-import models.KindOfPackage
 /**
- * Represents the packages fields in the XML payload, i.e. the "Packages" section in GoodItems
+ * A 5-digit "special mention" code needed to indicate specific scenarios in the declaration
+ *
+ * e.g. when a notified party is provided for a goods item, we use code 10600
+ *
+ * TODO: When we have a code list this model may change to be more in line with similar enums
+ * like Country or PaymentMethod.
  */
-case class Packages(
-  kindPackage: KindOfPackage,
-  numPackages: Option[Int],
-  numPieces: Option[Int],
-  itemMark: String
-)
-
-object Packages {
-  implicit val format: OFormat[Packages] = Json.format[Packages]
-}
+case class SpecialMention(code: String)

--- a/app/serialisation/xml/GoodItemsFormats.scala
+++ b/app/serialisation/xml/GoodItemsFormats.scala
@@ -16,11 +16,16 @@
 
 package serialisation.xml
 
-import models.{Container, Document, DocumentType}
+import models.{Container, Country, Document, DocumentType, PaymentMethod}
+import models.completion.downstream._
 import scala.xml.NodeSeq
 import serialisation.xml.XmlImplicits._
 
-trait GoodItemsFormats extends CommonFormats {
+trait GoodItemsFormats
+  extends CommonFormats
+  with TransportFormats
+  with PackagesFormats
+  with PartyFormats {
 
   implicit val containerFmt = new Format[Container] {
     override def encode(container: Container): NodeSeq = {
@@ -32,7 +37,7 @@ trait GoodItemsFormats extends CommonFormats {
   implicit val documentTypeFormat = new StringFormat[DocumentType] {
     override def encode(docType: DocumentType): String = docType.code
     override def decode(s: String): DocumentType = {
-      DocumentType.allDocumentTypes.find { _.code == s}.getOrElse{
+      DocumentType.allDocumentTypes.find { _.code == s }.getOrElse {
         throw new XmlDecodingException(s"Bad Document code: $s")
       }
     }
@@ -50,4 +55,137 @@ trait GoodItemsFormats extends CommonFormats {
       )
     }
   }
+
+  implicit val goodsItemIdentityByCodeFmt = new Format[GoodsItemIdentity.ByCommodityCode] {
+    override def encode(id: GoodsItemIdentity.ByCommodityCode): NodeSeq = {
+      <COMCODGODITM>{id.code}</COMCODGODITM>
+    }
+    override def decode(data: NodeSeq): GoodsItemIdentity.ByCommodityCode = {
+      GoodsItemIdentity.ByCommodityCode((data \\ "COMCODGODITM").text)
+    }
+  }
+
+  implicit val goodsItemIdentityWithDescFmt = new Format[GoodsItemIdentity.WithDescription] {
+    override def encode(id: GoodsItemIdentity.WithDescription): NodeSeq = {
+      <GooDesGDS23>{id.desc}</GooDesGDS23>
+    }
+    override def decode(data: NodeSeq): GoodsItemIdentity.WithDescription = {
+      GoodsItemIdentity.WithDescription((data \\ "GooDesGDS23").text)
+    }
+  }
+
+  implicit val goodsItemIdentityFmt = new Format[GoodsItemIdentity] {
+    override def encode(id: GoodsItemIdentity): NodeSeq = id match {
+      case g: GoodsItemIdentity.ByCommodityCode => g.toXml
+      case g: GoodsItemIdentity.WithDescription => g.toXml
+    }
+
+    override def decode(data: NodeSeq): GoodsItemIdentity = {
+      if ((data \\ "COMCODGODITM").nonEmpty) {
+        data.parseXml[GoodsItemIdentity.ByCommodityCode]
+      } else {
+        data.parseXml[GoodsItemIdentity.WithDescription]
+      }
+    }
+  }
+
+  implicit val dangerousGoodCodeFmt: StringFormat[DangerousGoodsCode] = {
+    StringFormat.simple(_.code, c => DangerousGoodsCode(c))
+  }
+
+  implicit val loadingPlaceFmt = new StringFormat[LoadingPlace] {
+    override def encode(id: LoadingPlace): String = s"${id.country.toXmlString} ${id.desc}"
+
+    override def decode(s: String): LoadingPlace = s.split(" ").toList match {
+      case countryCode :: remainder =>
+        LoadingPlace(
+          countryCode.parseXmlString[Country],
+          remainder.mkString(" ")
+        )
+      case _ =>
+        throw new XmlDecodingException(s"Unexpected format for loading place: '$s'")
+    }
+  }
+
+  implicit val specialMentionFmt: StringFormat[SpecialMention] = {
+    StringFormat.simple(_.code, SpecialMention(_))
+  }
+
+  implicit val goodsItemFmt = new Format[GoodsItem] {
+    override def encode(item: GoodsItem): NodeSeq = {
+      val grossMass: NodeSeq = item.grossMass.map { m =>
+        <GroMasGDS46>{m.toXmlString}</GroMasGDS46>
+      }.toSeq
+
+      val dangerousGoodsCode: NodeSeq = item.dangerousGoodsCode.map { c =>
+        <UNDanGooCodGDI1>{c.toXmlString}</UNDanGooCodGDI1>
+      }.toSeq
+
+      val documents: NodeSeq = item.documents map { d => <PRODOCDC2>{d.toXml}</PRODOCDC2> }
+
+      val specialMentions: NodeSeq = item.specialMentions map {
+        sm => <SPEMENMT2>{sm.toXmlString}</SPEMENMT2>
+      }
+
+      val consignee: NodeSeq = item.consignee.map { c =>
+        <TRACONCE2>{goodsConsigneeFormat.encode(c)}</TRACONCE2>
+      }.toSeq
+
+      val containers: NodeSeq = item.containers map { c => <CONNR2>{c.toXml}</CONNR2> }
+
+      val packages: NodeSeq = item.packages map { p => <PACGS2>{p.toXml}</PACGS2> }
+
+      val notifiedParty: NodeSeq = item.notifiedParty.map { np =>
+        <PRTNOT640>{goodsNotifiedPartyFormat.encode(np)}</PRTNOT640>
+      }.toSeq
+
+      // The ItemIdentity type spans two fields which need to be in different positions in the seq
+      // of tags, so unfortunately we have to break it up like this rather than just use a single
+      // encoder for the overall GoodsItemIdentity type, to put those fields in the correct pos
+      val commCode: NodeSeq = item.itemIdentity match {
+        case id: GoodsItemIdentity.ByCommodityCode => id.toXml
+        case _ => Nil
+      }
+      val desc: NodeSeq = item.itemIdentity match {
+        case id: GoodsItemIdentity.WithDescription => id.toXml
+        case _ => Nil
+      }
+
+      Seq(
+        <IteNumGDS7>{item.itemNumber}</IteNumGDS7>,
+        desc,
+        grossMass,
+        <MetOfPayGDI12>{item.paymentMethod.toXmlString}</MetOfPayGDI12>,
+        dangerousGoodsCode,
+        <PlaLoaGOOITE333>{item.placeOfLoading.toXmlString}</PlaLoaGOOITE333>,
+        <PlaUnlGOOITE333>{item.placeOfUnloading.toXmlString}</PlaUnlGOOITE333>,
+        documents,
+        specialMentions,
+        <TRACONCO2>{goodsConsignorFormat.encode(item.consignor)}</TRACONCO2>,
+        commCode,
+        consignee,
+        containers,
+        packages,
+        notifiedParty
+      ).flatten
+    }
+
+    override def decode(data: NodeSeq): GoodsItem = GoodsItem(
+      itemNumber = (data \\ "IteNumGDS7").text.toInt,
+      itemIdentity = data.parseXml[GoodsItemIdentity],
+      grossMass = (data \\ "GroMasGDS46").headOption map { _.text.parseXmlString[BigDecimal] },
+      paymentMethod = (data \\ "MetOfPayGDI12").text.parseXmlString[PaymentMethod],
+      dangerousGoodsCode = (data \\ "UNDanGooCodGDI1").headOption map { _.text.parseXmlString[DangerousGoodsCode] },
+      placeOfLoading = (data \\ "PlaLoaGOOITE333").text.parseXmlString[LoadingPlace],
+      placeOfUnloading = (data \\ "PlaUnlGOOITE333").text.parseXmlString[LoadingPlace],
+      documents = (data \\ "PRODOCDC2").map { _.parseXml[Document] }.toList,
+      consignor = goodsConsignorFormat.decode(data \\ "TRACONCO2"),
+      consignee = (data \\ "TRACONCE2").headOption.map(goodsConsigneeFormat.decode),
+      notifiedParty = (data \\ "PRTNOT640").headOption.map(goodsNotifiedPartyFormat.decode),
+      containers = (data \\ "CONNR2").map { _.parseXml[Container] }.toList,
+      packages = (data \\ "PACGS2").map { _.parseXml[Package] }.toList,
+      specialMentions = (data \\ "SPEMENMT2").map { _.text.parseXmlString[SpecialMention] }.toList
+    )
+  }
+
 }

--- a/app/serialisation/xml/PackagesFormats.scala
+++ b/app/serialisation/xml/PackagesFormats.scala
@@ -18,7 +18,7 @@ package serialisation.xml
 
 import scala.xml.NodeSeq
 
-import models.completion.downstream.Packages
+import models.completion.downstream.Package
 import models.KindOfPackage
 import serialisation.xml.XmlImplicits._
 
@@ -33,27 +33,31 @@ trait PackagesFormats extends CommonFormats {
     }
   }
 
-  implicit val packagesFmt = new Format[Packages] {
-    override def encode(packages: Packages): NodeSeq = {
+  implicit val packageFmt = new Format[Package] {
+    override def encode(p: Package): NodeSeq = {
       val numPackages: NodeSeq = {
-        packages.numPackages.map { n => <NumOfPacGS24>{n}</NumOfPacGS24> }.toSeq
+        p.numPackages.map { n => <NumOfPacGS24>{n}</NumOfPacGS24> }.toSeq
       }
       val numPieces: NodeSeq = {
-        packages.numPieces.map { n => <NumOfPieGS25>{n}</NumOfPieGS25> }.toSeq
+        p.numPieces.map { n => <NumOfPieGS25>{n}</NumOfPieGS25> }.toSeq
       }
+      val mark: NodeSeq = {
+        p.mark.map { m => <MarNumOfPacGSL21>{m}</MarNumOfPacGSL21> }.toSeq
+      }
+
       Seq(
-        <KinOfPacGS23>{packages.kindPackage.toXmlString}</KinOfPacGS23>,
+        <KinOfPacGS23>{p.kindPackage.toXmlString}</KinOfPacGS23>,
         numPackages,
         numPieces,
-        <MarNumOfPacGSL21>{packages.itemMark}</MarNumOfPacGSL21>
+        mark
       ).flatten
     }
 
-    override def decode(data: NodeSeq): Packages = Packages(
+    override def decode(data: NodeSeq): Package = Package(
       kindPackage = (data \\ "KinOfPacGS23").text.parseXmlString[KindOfPackage],
       numPackages = (data \\ "NumOfPacGS24").headOption map { _.text.toInt },
       numPieces = (data \\ "NumOfPieGS25").headOption map { _.text.toInt },
-      itemMark = (data \\ "MarNumOfPacGSL21").text
+      mark = (data \\ "MarNumOfPacGSL21").headOption map { _.text }
     )
   }
 }

--- a/test/serialisation/xml/GoodItemsFormatsSpec.scala
+++ b/test/serialisation/xml/GoodItemsFormatsSpec.scala
@@ -18,7 +18,7 @@ package serialisation.xml
 
 import base.SpecBase
 import models.{Container, Document, DocumentType}
-import org.scalacheck.Arbitrary
+import models.completion.downstream._
 import org.scalacheck.Arbitrary.arbitrary
 import org.scalacheck.Gen
 import org.scalatestplus.scalacheck.ScalaCheckPropertyChecks
@@ -28,13 +28,7 @@ class GoodItemsFormatsSpec extends SpecBase
   with XmlImplicits
   with ScalaCheckPropertyChecks {
 
-  override implicit lazy val arbitraryDocumentType: Arbitrary[DocumentType] = {
-    Arbitrary {
-      Gen.oneOf(DocumentType.allDocumentTypes)
-    }
-  }
-
-  private val document: Gen[Document] = {
+  private val documents: Gen[Document] = {
     for {
       docType <- arbitrary[DocumentType]
       ref <- Gen.alphaNumStr
@@ -42,14 +36,14 @@ class GoodItemsFormatsSpec extends SpecBase
   }
 
   "The container format" - {
-    "should parse one container" in {
+    "should work symmetrically" in {
       val container = Container("0103")
       container.toXml.parseXml[Container] must be(container)
     }
   }
 
   "The DocumentType Format" - {
-    "should parse one documentType" in {
+    "should work symmetrically" in {
       forAll(arbitrary[DocumentType]) { c =>
         c.toXmlString.parseXmlString[DocumentType] must be(c)
       }
@@ -57,9 +51,199 @@ class GoodItemsFormatsSpec extends SpecBase
   }
 
   "The Document Format" - {
-    "should parse one doucment" in {
-      forAll(arbitrary[Document]) { c =>
+    "should work symmetrically" in {
+      forAll(documents) { c =>
         c.toXml.parseXml[Document] must be(c)
+      }
+    }
+  }
+
+  "The goods item identity format" - {
+    "by commodity code" - {
+      "should work symmetrically" in {
+        forAll(arbitrary[GoodsItemIdentity.ByCommodityCode]) { id =>
+          id.toXml.parseXml[GoodsItemIdentity.ByCommodityCode] must be(id)
+        }
+      }
+    }
+
+    "with description" - {
+      "should work symmetrically" in {
+        forAll(arbitrary[GoodsItemIdentity.WithDescription]) { id =>
+          id.toXml.parseXml[GoodsItemIdentity.WithDescription] must be(id)
+        }
+      }
+    }
+
+    "unified type" - {
+      "should work symmetrically" in {
+        forAll(arbitrary[GoodsItemIdentity]) { id =>
+          id.toXml.parseXml[GoodsItemIdentity] must be(id)
+        }
+      }
+    }
+  }
+
+  "The dangerous goods code format" - {
+    "should work symmetrically" in {
+      forAll(arbitrary[DangerousGoodsCode]) { good =>
+        good.toXmlString.parseXmlString[DangerousGoodsCode] must be(good)
+      }
+    }
+  }
+
+  "The loading place format" - {
+    "should work symmetrically" in {
+      forAll(arbitrary[LoadingPlace]) { lp =>
+        lp.toXmlString.parseXmlString[LoadingPlace] must be(lp)
+      }
+    }
+
+    "should serialise to country code plus description, space-delimited" in {
+      forAll(arbitrary[LoadingPlace]) { lp =>
+        lp.toXmlString must be(s"${lp.country.code} ${lp.desc}")
+      }
+    }
+  }
+
+  "The goods item format" - {
+    "should work symmetrically" - {
+      "for any good item" in {
+        forAll(arbitrary[GoodsItem]) { item =>
+          item.toXml.parseXml[GoodsItem] must be(item)
+        }
+      }
+
+      "when gross mass" - {
+        "is specified" in {
+          val gen = for {
+            item <- arbitrary[GoodsItem]
+            mass <- Gen.choose(BigDecimal("0.001"), BigDecimal("99999999.999"))
+          } yield item.copy(grossMass = Some(mass))
+
+          forAll(gen) { item => item.toXml.parseXml[GoodsItem] must be(item) }
+        }
+
+        "is missing" in {
+          val gen = arbitrary[GoodsItem] map { _.copy(grossMass = None) }
+          forAll(gen) { item => item.toXml.parseXml[GoodsItem] must be(item) }
+        }
+      }
+
+      "when dangerous goods code" - {
+        "is specified" in {
+          val gen = for {
+            item <- arbitrary[GoodsItem]
+            code <- arbitrary[DangerousGoodsCode]
+          } yield item.copy(dangerousGoodsCode = Some(code))
+
+          forAll(gen) { item => item.toXml.parseXml[GoodsItem] must be(item) }
+        }
+
+        "is missing" in {
+          val gen = arbitrary[GoodsItem] map { _.copy(dangerousGoodsCode = None) }
+          forAll(gen) { item => item.toXml.parseXml[GoodsItem] must be(item) }
+        }
+      }
+
+      "when documents" - {
+        "are present" in {
+          val gen = for {
+            item <- arbitrary[GoodsItem]
+            len <- Gen.choose(1, 99)
+            docs <- Gen.listOfN(len, arbitrary[Document])
+          } yield item.copy(documents = docs)
+
+          forAll(gen) { item => item.toXml.parseXml[GoodsItem] must be(item) }
+        }
+
+        "are absent" in {
+          val gen = arbitrary[GoodsItem] map { _.copy(documents = Nil) }
+          forAll(gen) { item => item.toXml.parseXml[GoodsItem] must be(item) }
+        }
+      }
+
+      "when consignee" - {
+        "is specified" in {
+          val gen = for {
+            item <- arbitrary[GoodsItem]
+            con <- arbitrary[Party]
+          } yield item.copy(consignee = Some(con))
+
+          forAll(gen) { item => item.toXml.parseXml[GoodsItem] must be(item) }
+        }
+
+        "is missing" in {
+          val gen = arbitrary[GoodsItem] map { _.copy(consignee = None) }
+          forAll(gen) { item => item.toXml.parseXml[GoodsItem] must be(item) }
+        }
+      }
+
+      "when notified party" - {
+        "is specified" in {
+          val gen = for {
+            item <- arbitrary[GoodsItem]
+            party <- arbitrary[Party]
+          } yield item.copy(notifiedParty = Some(party))
+
+          forAll(gen) { item => item.toXml.parseXml[GoodsItem] must be(item) }
+        }
+
+        "is missing" in {
+          val gen = arbitrary[GoodsItem] map { _.copy(notifiedParty = None) }
+          forAll(gen) { item => item.toXml.parseXml[GoodsItem] must be(item) }
+        }
+      }
+
+      "when containers" - {
+        "are present" in {
+          val gen = for {
+            item <- arbitrary[GoodsItem]
+            len <- Gen.choose(1, 99)
+            containers <- Gen.listOfN(len, arbitrary[Container])
+          } yield item.copy(containers = containers)
+
+          forAll(gen) { item => item.toXml.parseXml[GoodsItem] must be(item) }
+        }
+
+        "are absent" in {
+          val gen = arbitrary[GoodsItem] map { _.copy(containers = Nil) }
+          forAll(gen) { item => item.toXml.parseXml[GoodsItem] must be(item) }
+        }
+      }
+
+      "when packages" - {
+        "are present" in {
+          val gen = for {
+            item <- arbitrary[GoodsItem]
+            len <- Gen.choose(1, 99)
+            packages <- Gen.listOfN(len, arbitrary[Package])
+          } yield item.copy(packages = packages)
+
+          forAll(gen) { item => item.toXml.parseXml[GoodsItem] must be(item) }
+        }
+
+        "are absent" in {
+          val gen = arbitrary[GoodsItem] map { _.copy(packages = Nil) }
+          forAll(gen) { item => item.toXml.parseXml[GoodsItem] must be(item) }
+        }
+      }
+
+      "when special mentions" - {
+        "are present" in {
+          val gen = for {
+            item <- arbitrary[GoodsItem]
+            len <- Gen.choose(1, 10)
+            mentions <- Gen.listOfN(len, arbitrary[SpecialMention])
+          } yield item.copy(specialMentions = mentions)
+
+          forAll(gen) { item => item.toXml.parseXml[GoodsItem] must be(item) }
+        }
+
+        "are absent" in {
+          val gen = arbitrary[GoodsItem] map { _.copy(specialMentions = Nil) }
+          forAll(gen) { item => item.toXml.parseXml[GoodsItem] must be(item) }
+        }
       }
     }
   }

--- a/test/serialisation/xml/PackagesFormatsSpec.scala
+++ b/test/serialisation/xml/PackagesFormatsSpec.scala
@@ -17,7 +17,7 @@
 package serialisation.xml
 
 import base.SpecBase
-import models.completion.downstream.Packages
+import models.completion.downstream.Package
 import models.KindOfPackage
 import org.scalacheck.Arbitrary.arbitrary
 import org.scalacheck.Gen
@@ -29,26 +29,27 @@ class PackagesFormatsSpec
   with ScalaCheckPropertyChecks
   with XmlImplicits {
 
-  "The packages format" - {
+  "The package format" - {
     "should serialise symmetrically" in {
       val packagesGen = for {
         kindPackage <- arbitrary[KindOfPackage]
         numPackages <- Gen.option(Gen.choose(0, 99999))
         numPieces <- Gen.option(Gen.choose(0, 99999))
-        itemMark <- Gen.alphaStr.map { _.take(2) }
-      } yield Packages(kindPackage, numPackages, numPieces, itemMark)
+        mark <- Gen.option(Gen.alphaStr.map { _.take(2) })
+      } yield Package(kindPackage, numPackages, numPieces, mark)
 
       forAll(packagesGen) { p =>
-        p.toXml.parseXml[Packages] must be(p)
+        p.toXml.parseXml[Package] must be(p)
       }
     }
   }
 
   "The kind of package Format" - {
     "should serialise symmetrically" in {
-      val packages = Gen.oneOf(KindOfPackage.standardKindsOfPackages)
-      forAll(packages) { p =>
-        p.toXmlString.parseXmlString[KindOfPackage] must be(p)
+      val kinds = Gen.oneOf(KindOfPackage.standardKindsOfPackages)
+
+      forAll(kinds) { k =>
+        k.toXmlString.parseXmlString[KindOfPackage] must be(k)
       }
     }
   }


### PR DESCRIPTION
Add models for the good item section of the XML payload

Some of these models are similar to journey models but kept distinct as
they represent the data in a slightly different way, e.g.
DangerousGoodsCode, LoadingPlace.

Make some required changes to Package:
  - mark is optional, and simplify the name slightly
  - rename it from plural since it represents one package entry and the
    pluralised name was a little confusing