### PR TITLE
SSUT-422: Fix uses of Gen.XXXStr + take(n)

### DIFF
--- a/app/models/completion/downstream/MessageSender.scala
+++ b/app/models/completion/downstream/MessageSender.scala
@@ -20,7 +20,8 @@ package models.completion.downstream
  * Identify the user "sending" the message, represented by EORI number and "branch"
  *
  * @param eori The EORI number of the user submitting the declaration
- * @param branch This is either "GB" + VAT reg number + "000", for VAT-registered businesses, or
- *               "GB" + a unique number issued by HMRC for non-VAT-registered businesses.
+ * @param branch This refers to the sub-office the user belongs to within the declaring
+ *   organisation, if applicable, and is a 10-digit number to distinguish the office within the
+ *   organisation's EORI.
  */
 case class MessageSender(eori: String, branch: String)

--- a/test-utils/generators/ModelGenerators.scala
+++ b/test-utils/generators/ModelGenerators.scala
@@ -63,19 +63,19 @@ trait ModelGenerators {
   implicit lazy val arbitraryRoroUnaccompaniedIdentity: Arbitrary[RoroUnaccompaniedIdentity] =
     Arbitrary {
       for {
-        trailerNumber <- Gen.alphaNumStr map { _.take(12) }
+        trailer <- Gen.listOfN(12, Gen.alphaNumChar)
         imo <- Gen.listOfN(8, Gen.numChar)
-        ferryCompany <- Gen.option(Gen.alphaNumStr map { _.take(12) })
-      } yield RoroUnaccompaniedIdentity(trailerNumber, imo.mkString, ferryCompany)
+        ferryCompany <- Gen.option(Gen.listOfN(12, Gen.alphaNumChar) map { _.mkString })
+      } yield RoroUnaccompaniedIdentity(trailer.mkString, imo.mkString, ferryCompany)
     }
 
   implicit lazy val arbitraryRoroAccompaniedIdentity: Arbitrary[RoroAccompaniedIdentity] =
     Arbitrary {
       for {
-        vehicleReg <- Gen.alphaNumStr map { _.take(12) }
-        trailer <- Gen.alphaNumStr map { _.take(12) }
-        ferry <- Gen.option(Gen.alphaNumStr map { _.take(12) })
-      } yield RoroAccompaniedIdentity(vehicleReg, trailer, ferry)
+        vehicleReg <- Gen.listOfN(12, Gen.alphaNumChar)
+        trailer <- Gen.listOfN(12, Gen.alphaNumChar)
+        ferry <- Gen.option(Gen.listOfN(12, Gen.alphaNumChar) map { _.mkString })
+      } yield RoroAccompaniedIdentity(vehicleReg.mkString, trailer.mkString, ferry)
     }
 
   implicit lazy val arbitraryRoadIdentity: Arbitrary[RoadIdentity] =
@@ -310,9 +310,9 @@ trait ModelGenerators {
 
   implicit lazy val arbitraryMessageSender: Arbitrary[MessageSender] = Arbitrary {
     for {
-      eori <- Gen.numStr map { _.take(15) }
-      vatNumber <- Gen.numStr map { _.take(7) }
-    } yield MessageSender("GB" + eori, s"GB${vatNumber}000")
+      eori <- arbitrary[GbEori]
+      branch <- Gen.listOfN(10, Gen.numChar)
+    } yield MessageSender("GB" + eori.value, branch.mkString)
   }
 
   implicit lazy val arbitraryMessageType: Arbitrary[MessageType] = Arbitrary {
@@ -334,15 +334,15 @@ trait ModelGenerators {
   implicit lazy val arbitraryPartyByEori: Arbitrary[Party.ByEori] = Arbitrary {
     for {
       country <- Gen.oneOf(Country.allCountries)
-      number <- Gen.numStr.map { _.take(12) }
+      number <- Gen.listOfN(12, Gen.numChar)
     } yield Party.ByEori(s"${country.code}$number")
   }
 
   implicit lazy val arbitraryPartyByAddress: Arbitrary[Party.ByAddress] = Arbitrary {
     for {
-      name <- Gen.alphaStr.map { _.take(40) }
+      name <- Gen.listOfN(40, Gen.alphaChar)
       addr <- arbitrary[Address]
-    } yield Party.ByAddress(name, addr)
+    } yield Party.ByAddress(name.mkString, addr)
   }
 
   implicit lazy val arbitraryParty: Arbitrary[Party] = Arbitrary {
@@ -358,7 +358,7 @@ trait ModelGenerators {
       kindPackage <- arbitrary[KindOfPackage]
       numPackages <- Gen.option(Gen.choose(0, 99999))
       numPieces <- Gen.option(Gen.choose(0, 99999))
-      mark <- Gen.option(Gen.alphaStr.map { _.take(2) })
+      mark <- Gen.option(Gen.listOfN(2, Gen.alphaChar) map { _.mkString })
     } yield Package(kindPackage, numPackages, numPieces, mark)
   }
 

--- a/test/controllers/transport/RoroAccompaniedIdentityControllerSpec.scala
+++ b/test/controllers/transport/RoroAccompaniedIdentityControllerSpec.scala
@@ -38,7 +38,9 @@ class RoroAccompaniedIdentityControllerSpec extends SpecBase with MockitoSugar {
   private val formProvider = new RoroAccompaniedIdentityFormProvider()
   private val form = formProvider()
 
-  private lazy val roroAccompaniedIdentityRoute = routes.RoroAccompaniedIdentityController.onPageLoad(NormalMode, lrn).url
+  private lazy val roroAccompaniedIdentityRoute = {
+    routes.RoroAccompaniedIdentityController.onPageLoad(NormalMode, lrn).url
+  }
 
   private val id = arbitrary[RoroAccompaniedIdentity].sample.value
   private val formData: List[(String, String)] = List(

--- a/test/serialisation/xml/MetadataFormatsSpec.scala
+++ b/test/serialisation/xml/MetadataFormatsSpec.scala
@@ -23,6 +23,7 @@ import org.scalacheck.Gen
 import org.scalatestplus.scalacheck.ScalaCheckPropertyChecks
 
 import base.SpecBase
+import models.GbEori
 import models.completion.downstream.{MessageSender, MessageType, Metadata}
 
 class MetadataFormatsSpec
@@ -32,9 +33,9 @@ class MetadataFormatsSpec
   with XmlImplicits {
 
   private val senders: Gen[MessageSender] = for {
-    eori <- Gen.numStr map { _.take(15) }
-    vatNumber <- Gen.numStr map { _.take(7) }
-  } yield MessageSender("GB" + eori, s"GB${vatNumber}000")
+    eori <- arbitrary[GbEori]
+    branch <- Gen.listOfN(10, Gen.numChar)
+  } yield MessageSender("GB" + eori.value, branch.mkString)
 
   "The message type format" - {
     "should serialise symmetrically" in {
@@ -71,7 +72,7 @@ class MetadataFormatsSpec
   "The metadata format" - {
     "should serialise symmetrically" in {
       val metadataGen = for {
-        messageId <- Gen.alphaNumStr.map { _.take(20) }
+        messageId <- stringsWithExactLength(20)
         messageSender <- arbitrary[MessageSender]
         messageType <- arbitrary[MessageType]
         dt <- minutePrecisionInstants

--- a/test/serialisation/xml/PackagesFormatsSpec.scala
+++ b/test/serialisation/xml/PackagesFormatsSpec.scala
@@ -35,7 +35,7 @@ class PackagesFormatsSpec
         kindPackage <- arbitrary[KindOfPackage]
         numPackages <- Gen.option(Gen.choose(0, 99999))
         numPieces <- Gen.option(Gen.choose(0, 99999))
-        mark <- Gen.option(Gen.alphaStr.map { _.take(2) })
+        mark <- Gen.option(stringsWithExactLength(2))
       } yield Package(kindPackage, numPackages, numPieces, mark)
 
       forAll(packagesGen) { p =>

--- a/test/serialisation/xml/PartyFormatsSpec.scala
+++ b/test/serialisation/xml/PartyFormatsSpec.scala
@@ -32,11 +32,11 @@ class PartyFormatsSpec
 
   private val partyByEori: Gen[Party] = for {
     country <- Gen.oneOf(Country.allCountries)
-    number <- Gen.numStr.map { _.take(12) }
-  } yield Party.ByEori(s"${country.code}$number")
+    number <- Gen.listOfN(12, Gen.numChar)
+  } yield Party.ByEori(s"${country.code}${number.mkString}")
 
   private val partyByAddress: Gen[Party] = for {
-    name <- Gen.alphaStr.map { _.take(40) }
+    name <- stringsWithMaxLength(40)
     addr <- arbitrary[Address]
   } yield Party.ByAddress(name, addr)
 


### PR DESCRIPTION
Gen.alphaStr / Gen.alphaNumStr etc. have the possibility of producing
very short strings or even zero-length strings, which make this approach
of creating strings of certain length, or even of certain max length,
unreliable, and thios caused a controller test to fail rarely due to
zero-length strings being submitted to the form when valid data was
expected.

Fix all uses of this in ModelGenerators to the more reliable Gen.listOfN
+ Gen.XXXChar approach.
Fix uses of this in a handful of tests to the same, or else reusing the
utils in Generators (stringsOfMaxLength etc.) where applicable.
Also replaced a couple of generated strings with arbitrary[GbEori] since
they were generating a GB EORI anyway.

While I'm here I updated the definition of the arbitrary MessageSender,
since this was one of the affected arbitrary generators, and updated the
scaladoc on this model to reflect what "branch" really is, since we've
since clarified the meaning of this field.