### PR TITLE
SSUT-460: Validate submissions against schemata

### DIFF
--- a/app/models/completion/downstream/Submission.scala
+++ b/app/models/completion/downstream/Submission.scala
@@ -19,6 +19,7 @@ package models.completion.downstream
 import models.completion.{CustomsOffice, Itinerary}
 
 case class Submission(
+  metadata: Metadata,
   header: Header,
   goodsItems: List[GoodsItem],
   itinerary: Itinerary,

--- a/app/serialisation/xml/HeaderFormats.scala
+++ b/app/serialisation/xml/HeaderFormats.scala
@@ -32,13 +32,26 @@ trait HeaderFormats extends TransportFormats with TimeFormats {
         header.grossMass.map { v => <TotGroMasHEA307>{v.toXmlString}</TotGroMasHEA307> }.toSeq
       }
 
+      // Unfortunately we can't simply write using the TransportDetails format because we have to
+      // position the individual fields in the right places across the header
+      val transportNationality: NodeSeq = header.transportDetails.nationality.map { n =>
+        <NatOfMeaOfTraCroHEA87>{n.toXmlString}</NatOfMeaOfTraCroHEA87>
+      }.toSeq
+
+      val transportPaymentMethod: NodeSeq = header.transportDetails.paymentMethod.map { pm =>
+        <TraChaMetOfPayHEA1>{pm.toXmlString}</TraChaMetOfPayHEA1>
+      }.toSeq
+
       <HEAHEA>
         <RefNumHEA4>{header.lrn.toXmlString}</RefNumHEA4>
-        {header.transportDetails.toXml}
+        <TraModAtBorHEA76>{header.transportDetails.mode.toXmlString}</TraModAtBorHEA76>
+        <IdeOfMeaOfTraCroHEA85>{header.transportDetails.identity}</IdeOfMeaOfTraCroHEA85>
+        {transportNationality}
         <TotNumOfIteHEA305>{header.itemCount}</TotNumOfIteHEA305>
         <TotNumOfPacHEA306>{header.packageCount}</TotNumOfPacHEA306>
         {grossMass}
         <DecPlaHEA394>{header.declarationPlace}</DecPlaHEA394>
+        {transportPaymentMethod}
         <ConRefNumHEA>{header.conveyanceReferenceNumber}</ConRefNumHEA>
         <DecDatTimHEA114>{header.datetime.toXmlString}</DecDatTimHEA114>
       </HEAHEA>

--- a/app/serialisation/xml/MetadataFormats.scala
+++ b/app/serialisation/xml/MetadataFormats.scala
@@ -28,8 +28,8 @@ trait MetadataFormats {
   // N.B. we aren't using the StringFormat in TimeFormats because we have to serialise multiple
   // fields for a separate date + time in the message metadata fields
   implicit val metadataInstantFmt = new Format[Instant] {
-    private val dtFmt = DateTimeFormatter.ofPattern("yyyyMMddHHmm").withZone(ZoneId.from(ZoneOffset.UTC))
-    private val dateFmt = DateTimeFormatter.ofPattern("yyyyMMdd").withZone(ZoneId.from(ZoneOffset.UTC))
+    private val dtFmt = DateTimeFormatter.ofPattern("ddMMyyHHmm").withZone(ZoneId.from(ZoneOffset.UTC))
+    private val dateFmt = DateTimeFormatter.ofPattern("ddMMyy").withZone(ZoneId.from(ZoneOffset.UTC))
     private val timeFmt = DateTimeFormatter.ofPattern("HHmm").withZone(ZoneId.from(ZoneOffset.UTC))
 
     override def encode(dt: Instant): NodeSeq = {
@@ -66,9 +66,9 @@ trait MetadataFormats {
   implicit val metadataFmt = new Format[Metadata] {
     override def encode(metadata: Metadata): NodeSeq = Seq(
       <MesSenMES3>{metadata.messageSender.toXmlString}</MesSenMES3>,
+      metadata.datetime.toXml,
       <MesIdeMES19>{metadata.messageId}</MesIdeMES19>,
-      <MesTypMES20>{metadata.messageType.toXmlString}</MesTypMES20>,
-      metadata.datetime.toXml
+      <MesTypMES20>{metadata.messageType.toXmlString}</MesTypMES20>
     ).flatten
 
     override def decode(data: NodeSeq): Metadata = Metadata(

--- a/app/serialisation/xml/SubmissionFormats.scala
+++ b/app/serialisation/xml/SubmissionFormats.scala
@@ -17,7 +17,7 @@
 package serialisation.xml
 
 import models.completion.{CustomsOffice, Itinerary}
-import models.completion.downstream.{GoodsItem, Header, Submission}
+import models.completion.downstream.{GoodsItem, Header, Metadata, Submission}
 
 import scala.xml.NodeSeq
 import serialisation.xml.XmlImplicits._
@@ -38,10 +38,11 @@ trait SubmissionFormats
       }
 
       val seals: NodeSeq = sub.seals map {
-        s => <SEAID529>{s}</SEAID529>
+        s => <SEAID529><SeaIdSEAID530>{s}</SeaIdSEAID530></SEAID529>
       }
 
       <ie:CC315A xmlns:ie="http://ics.dgtaxud.ec/CC315A">
+        {sub.metadata.toXml}
         {sub.header.toXml}
         {goodsItems}
         {sub.itinerary.toXml}
@@ -53,11 +54,12 @@ trait SubmissionFormats
     }
 
     override def decode(data: NodeSeq): Submission = Submission(
+      metadata = data.parseXml[Metadata],
       header = (data \ "HEAHEA").parseXml[Header],
       goodsItems = (data \ "GOOITEGDS").map { _.parseXml[GoodsItem] }.toList,
       itinerary = (data \ "ITI").parseXml[Itinerary],
       declarer = lodgingPersonFormat.decode(data \ "PERLODSUMDEC"),
-      seals = (data \ "SEAID529").map { _.text }.toList,
+      seals = (data \ "SEAID529" \ "SeaIdSEAID530").map { _.text }.toList,
       customsOffice = (data \ "CUSOFFFENT730").parseXml[CustomsOffice],
       carrier = carrierFormat.decode(data \ "TRACARENT601")
     )

--- a/test-utils/generators/Generators.scala
+++ b/test-utils/generators/Generators.scala
@@ -94,31 +94,6 @@ trait Generators
       .suchThat(_ != "true")
       .suchThat(_ != "false")
 
-  def nonEmptyString: Gen[String] =
-    Gen.alphaNumStr suchThat (_.nonEmpty)
-
-  def stringsWithExactLength(length: Int): Gen[String] =
-    for {
-      length <- length
-      chars <- listOfN(length, alphaNumChar)
-    } yield chars.mkString
-
-  def stringsWithMaxLength(maxLength: Int): Gen[String] =
-    for {
-      length <- choose(1, maxLength)
-      chars <- listOfN(length, alphaNumChar)
-    } yield chars.mkString
-
-  def stringsLongerThan(minLength: Int): Gen[String] =
-    for {
-      maxLength <- (minLength * 2).max(100)
-      length <- Gen.chooseNum(minLength + 1, maxLength)
-      chars <- listOfN(length, alphaNumChar)
-    } yield chars.mkString
-
-  def stringsExceptSpecificValues(excluded: Seq[String]): Gen[String] =
-    nonEmptyString suchThat (!excluded.contains(_))
-
   def oneOf[T](xs: Seq[Gen[T]]): Gen[T] =
     if (xs.isEmpty) {
       throw new IllegalArgumentException("oneOf called on empty collection")

--- a/test-utils/generators/StringGenerators.scala
+++ b/test-utils/generators/StringGenerators.scala
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2022 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package generators
+
+import org.scalacheck.Arbitrary.arbitrary
+import org.scalacheck.Gen
+import org.scalacheck.Gen._
+
+trait StringGenerators {
+  def nonEmptyString: Gen[String] =
+    arbitrary[String] suchThat (_.nonEmpty)
+
+  def stringsWithExactLength(length: Int): Gen[String] =
+    for {
+      length <- length
+      chars <- listOfN(length, alphaNumChar)
+    } yield chars.mkString
+
+  def stringsWithMaxLength(maxLength: Int): Gen[String] =
+    for {
+      length <- choose(1, maxLength)
+      chars <- listOfN(length, alphaNumChar)
+    } yield chars.mkString
+
+  def stringsLongerThan(minLength: Int): Gen[String] =
+    for {
+      maxLength <- (minLength * 2).max(100)
+      length <- chooseNum(minLength + 1, maxLength)
+      chars <- listOfN(length, alphaNumChar)
+    } yield chars.mkString
+
+  def stringsExceptSpecificValues(excluded: Seq[String]): Gen[String] =
+    nonEmptyString suchThat (!excluded.contains(_))
+
+}
+
+object StringGenerators extends StringGenerators

--- a/test/resources/schema/CC315A-v11-2.xsd
+++ b/test/resources/schema/CC315A-v11-2.xsd
@@ -1,0 +1,1257 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:ie="http://ics.dgtaxud.ec/CC315A"
+           targetNamespace="http://ics.dgtaxud.ec/CC315A" xmlns:doc="http://ics.dgtaxud.ec/doc" xmlns:complex_ics="http://ics.dgtaxud.ec/complex_ics" xmlns:simple="http://ics.dgtaxud.ec/simple" xmlns:tcl="http://ics.dgtaxud.ec/tcl" version="11.1" id="CC315A" elementFormDefault="unqualified" attributeFormDefault="unqualified">
+  <xs:import namespace="http://ics.dgtaxud.ec/doc" schemaLocation="doc-v11-2.xsd"/>
+  <xs:import namespace="http://ics.dgtaxud.ec/complex_ics" schemaLocation="complex_types_ics-v11-2.xsd"/>
+  <xs:import namespace="http://ics.dgtaxud.ec/simple" schemaLocation="simple_types-v11-2.xsd"/>
+  <xs:import namespace="http://ics.dgtaxud.ec/tcl" schemaLocation="tcl-v11-2.xsd"/>
+  <xs:element name="CC315A" type="ie:CC315AType"/>
+  <xs:complexType name="CC315AType">
+    <xs:sequence>
+      <xs:group ref="ie:MESSAGE"/>
+      <xs:element name="HEAHEA" type="ie:HEAHEAType">
+        <xs:annotation>
+          <xs:documentation>
+            <doc:description value="HEADER"/>
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element minOccurs="0" name="TRACONCO1" type="ie:TRACONCO1Type">
+        <xs:annotation>
+          <xs:documentation>
+            <doc:description value="(CONSIGNOR) TRADER"/>
+            <doc:condition name="C511"/>
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element minOccurs="0" name="TRACONCE1" type="ie:TRACONCE1Type">
+        <xs:annotation>
+          <xs:documentation>
+            <doc:description value="(CONSIGNEE) TRADER"/>
+            <doc:condition name="C583"/>
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element minOccurs="0" name="NOTPAR670" type="ie:NOTPAR670Type">
+        <xs:annotation>
+          <xs:documentation>
+            <doc:description value="NOTIFY PARTY"/>
+            <doc:condition name="C583"/>
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element maxOccurs="unbounded" name="GOOITEGDS" type="ie:GOOITEGDSType">
+        <xs:annotation>
+          <xs:documentation>
+            <doc:description value="GOODS ITEM"/>
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element minOccurs="0" maxOccurs="99" name="ITI" type="complex_ics:ITIType">
+        <xs:annotation>
+          <xs:documentation>
+            <doc:description value="ITINERARY"/>
+            <doc:rule name="R879"/>
+            <doc:condition name="C570"/>
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element minOccurs="0" name="CUSOFFLON" type="ie:CUSOFFLONType">
+        <xs:annotation>
+          <xs:documentation>
+            <doc:description value="(LODGEMENT) CUSTOMS OFFICE"/>
+            <doc:rule name="R827"/>
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element minOccurs="0" name="TRAREP" type="ie:TRAREPType">
+        <xs:annotation>
+          <xs:documentation>
+            <doc:description value="(REPRESENTATIVE) TRADER"/>
+            <doc:rule name="R896"/>
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="PERLODSUMDEC" type="ie:PERLODSUMDECType">
+        <xs:annotation>
+          <xs:documentation>
+            <doc:description value="(LODGING SUMMARY DECLARATION) PERSON"/>
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element minOccurs="0" maxOccurs="unbounded" name="SEAID529" type="complex_ics:SEAID529Type">
+        <xs:annotation>
+          <xs:documentation>
+            <doc:description value="SEALS ID"/>
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="CUSOFFFENT730" type="ie:CUSOFFFENT730Type">
+        <xs:annotation>
+          <xs:documentation>
+            <doc:description value="(FIRST ENTRY) CUSTOMS OFFICE"/>
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element minOccurs="0" maxOccurs="99" name="CUSOFFSENT740" type="complex_ics:CUSOFFSENT740Type">
+        <xs:annotation>
+          <xs:documentation>
+            <doc:description value="(SUBSEQUENT ENTRY) CUSTOMS OFFICE"/>
+            <doc:rule name="R808"/>
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element minOccurs="0" name="TRACARENT601" type="ie:TRACARENT601Type">
+        <xs:annotation>
+          <xs:documentation>
+            <doc:description value="(ENTRY CARRIER) TRADER"/>
+            <doc:rule name="R806"/>
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:group name="MESSAGE">
+    <xs:sequence>
+      <xs:element name="MesSenMES3" type="simple:Alphanumeric_Max35">
+        <xs:annotation>
+          <xs:documentation>
+            <doc:description value="Message sender"/>
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element minOccurs="0" name="MesRecMES6" type="simple:Alphanumeric_Max35">
+        <xs:annotation>
+          <xs:documentation>
+            <doc:description value="Message recipient"/>
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="DatOfPreMES9" type="simple:DatePrepType">
+        <xs:annotation>
+          <xs:documentation>
+            <doc:description value="Date of preparation"/>
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="TimOfPreMES10" type="simple:TimeType">
+        <xs:annotation>
+          <xs:documentation>
+            <doc:description value="Time of preparation"/>
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element minOccurs="0" name="PriMES15" type="simple:Alpha_1">
+        <xs:annotation>
+          <xs:documentation>
+            <doc:description value="Priority"/>
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="MesIdeMES19" type="simple:Alphanumeric_Max14">
+        <xs:annotation>
+          <xs:documentation>
+            <doc:description value="Message identification"/>
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="MesTypMES20" type="tcl:MessageTypes">
+        <xs:annotation>
+          <xs:documentation>
+            <doc:description value="Message type"/>
+            <doc:codeList name="MessageTypes"/>
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element minOccurs="0" name="CorIdeMES25" type="simple:Alphanumeric_Max14">
+        <xs:annotation>
+          <xs:documentation>
+            <doc:description value="Correlation identifier"/>
+            <doc:rule name="TR9181"/>
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:complexType name="HEAHEAType">
+    <xs:annotation>
+      <xs:documentation>
+        <doc:description value="HEADER"/>
+      </xs:documentation>
+    </xs:annotation>
+    <xs:sequence>
+      <xs:element name="RefNumHEA4" type="simple:Alphanumeric_Max22">
+        <xs:annotation>
+          <xs:documentation>
+            <doc:description value="Reference number"/>
+            <doc:rule name="R891"/>
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="TraModAtBorHEA76" type="simple:Numeric_Max2">
+        <xs:annotation>
+          <xs:documentation>
+            <doc:description value="Transport mode at border"/>
+            <doc:rule name="R826"/>
+            <doc:condition name="C529"/>
+            <doc:codeList name="TransportMode" type="business"/>
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element minOccurs="0" name="IdeOfMeaOfTraCroHEA85" type="simple:Alphanumeric_Max27">
+        <xs:annotation>
+          <xs:documentation>
+            <doc:description value="Identity of means of transport crossing border"/>
+            <doc:condition name="C017"/>
+            <doc:condition name="C514"/>
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element minOccurs="0" name="IdeOfMeaOfTraCroHEA85LNG" type="simple:LanguageCodeType">
+        <xs:annotation>
+          <xs:documentation>
+            <doc:description value="Identity of means of transport crossing border LNG"/>
+            <doc:rule name="TR0099"/>
+            <doc:codeList name="LanguageCodes" type="business"/>
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element minOccurs="0" name="NatOfMeaOfTraCroHEA87" type="simple:CountryCodeType">
+        <xs:annotation>
+          <xs:documentation>
+            <doc:description value="Nationality of means of transport crossing border"/>
+            <doc:condition name="C024"/>
+            <doc:codeList name="CountryCodesFullList" type="business"/>
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="TotNumOfIteHEA305" type="simple:Numeric_Max5">
+        <xs:annotation>
+          <xs:documentation>
+            <doc:description value="Total number of items"/>
+            <doc:rule name="TR0811"/>
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element minOccurs="0" name="TotNumOfPacHEA306" type="simple:Numeric_Max7">
+        <xs:annotation>
+          <xs:documentation>
+            <doc:description value="Total number of packages"/>
+            <doc:rule name="R105"/>
+            <doc:condition name="C582"/>
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element minOccurs="0" name="TotGroMasHEA307" type="simple:Decimal_11_3">
+        <xs:annotation>
+          <xs:documentation>
+            <doc:description value="Total gross mass"/>
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="DecPlaHEA394" type="simple:Alphanumeric_Max35">
+        <xs:annotation>
+          <xs:documentation>
+            <doc:description value="Declaration place"/>
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element minOccurs="0" name="DecPlaHEA394LNG" type="simple:LanguageCodeType">
+        <xs:annotation>
+          <xs:documentation>
+            <doc:description value="Declaration place LNG"/>
+            <doc:rule name="TR0099"/>
+            <doc:codeList name="LanguageCodes" type="business"/>
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element minOccurs="0" name="SpeCirIndHEA1" type="simple:AlphaCapital1Type">
+        <xs:annotation>
+          <xs:documentation>
+            <doc:description value="Specific Circumstance Indicator"/>
+            <doc:rule name="R834"/>
+            <doc:codeList name="SpecificCircumstanceIndicator" type="business"/>
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element minOccurs="0" name="TraChaMetOfPayHEA1" type="simple:AlphaCapital1Type">
+        <xs:annotation>
+          <xs:documentation>
+            <doc:description value="Transport charges/ Method of Payment"/>
+            <doc:codeList name="TransportChargesMethodOfPayment" type="business"/>
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element minOccurs="0" name="ComRefNumHEA" type="simple:Alphanumeric_Max70">
+        <xs:annotation>
+          <xs:documentation>
+            <doc:description value="Commercial Reference Number"/>
+            <doc:condition name="C567"/>
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element minOccurs="0" name="ConRefNumHEA" type="simple:Alphanumeric_Max35">
+        <xs:annotation>
+          <xs:documentation>
+            <doc:description value="Conveyance reference number"/>
+            <doc:rule name="R843"/>
+            <doc:condition name="C518"/>
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element minOccurs="0" name="PlaLoaGOOITE334" type="simple:AlphanumericSpecMax35Type">
+        <xs:annotation>
+          <xs:documentation>
+            <doc:description value="Place of loading"/>
+            <doc:rule name="R670"/>
+            <doc:condition name="C574"/>
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element minOccurs="0" name="PlaLoaGOOITE334LNG" type="simple:LanguageCodeType">
+        <xs:annotation>
+          <xs:documentation>
+            <doc:description value="Place of loading LNG"/>
+            <doc:rule name="TR0099"/>
+            <doc:codeList name="LanguageCodes" type="business"/>
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element minOccurs="0" name="PlaUnlGOOITE334" type="simple:AlphanumericSpecMax35Type">
+        <xs:annotation>
+          <xs:documentation>
+            <doc:description value="Place of unloading"/>
+            <doc:rule name="R670"/>
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element minOccurs="0" name="CodPlUnHEA357LNG" type="simple:LanguageCodeType">
+        <xs:annotation>
+          <xs:documentation>
+            <doc:description value="Place of unloading LNG"/>
+            <doc:rule name="TR0099"/>
+            <doc:codeList name="LanguageCodes" type="business"/>
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="DecDatTimHEA114" type="simple:DateTimeType">
+        <xs:annotation>
+          <xs:documentation>
+            <doc:description value="Declaration date and time"/>
+            <doc:rule name="R660"/>
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="TRACONCO1Type">
+    <xs:annotation>
+      <xs:documentation>
+        <doc:description value="(CONSIGNOR) TRADER"/>
+      </xs:documentation>
+    </xs:annotation>
+    <xs:sequence>
+      <xs:element minOccurs="0" name="NamCO17" type="simple:TradNameType">
+        <xs:annotation>
+          <xs:documentation>
+            <doc:description value="Name"/>
+            <doc:condition name="C501"/>
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element minOccurs="0" name="StrAndNumCO122" type="simple:StreetNumType">
+        <xs:annotation>
+          <xs:documentation>
+            <doc:description value="Street and number"/>
+            <doc:condition name="C501"/>
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element minOccurs="0" name="PosCodCO123" type="simple:PostalCodeType">
+        <xs:annotation>
+          <xs:documentation>
+            <doc:description value="Postal code"/>
+            <doc:condition name="C501"/>
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element minOccurs="0" name="CitCO124" type="simple:CityType">
+        <xs:annotation>
+          <xs:documentation>
+            <doc:description value="City"/>
+            <doc:condition name="C501"/>
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element minOccurs="0" name="CouCO125" type="simple:CountryCodeType">
+        <xs:annotation>
+          <xs:documentation>
+            <doc:description value="Country code"/>
+            <doc:condition name="C501"/>
+            <doc:codeList name="CountryCodesFullList" type="business"/>
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element minOccurs="0" name="NADLNGCO" type="simple:LanguageCodeType">
+        <xs:annotation>
+          <xs:documentation>
+            <doc:description value="NAD LNG"/>
+            <doc:rule name="TR0099"/>
+            <doc:codeList name="LanguageCodes" type="business"/>
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element minOccurs="0" name="TINCO159" type="simple:TINType">
+        <xs:annotation>
+          <xs:documentation>
+            <doc:description value="TIN"/>
+            <doc:rule name="R840"/>
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="TRACONCE1Type">
+    <xs:annotation>
+      <xs:documentation>
+        <doc:description value="(CONSIGNEE) TRADER"/>
+      </xs:documentation>
+    </xs:annotation>
+    <xs:sequence>
+      <xs:element minOccurs="0" name="NamCE17" type="simple:TradNameType">
+        <xs:annotation>
+          <xs:documentation>
+            <doc:description value="Name"/>
+            <doc:condition name="C501"/>
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element minOccurs="0" name="StrAndNumCE122" type="simple:StreetNumType">
+        <xs:annotation>
+          <xs:documentation>
+            <doc:description value="Street and number"/>
+            <doc:condition name="C501"/>
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element minOccurs="0" name="PosCodCE123" type="simple:PostalCodeType">
+        <xs:annotation>
+          <xs:documentation>
+            <doc:description value="Postal code"/>
+            <doc:condition name="C501"/>
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element minOccurs="0" name="CitCE124" type="simple:CityType">
+        <xs:annotation>
+          <xs:documentation>
+            <doc:description value="City"/>
+            <doc:condition name="C501"/>
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element minOccurs="0" name="CouCE125" type="simple:CountryCodeType">
+        <xs:annotation>
+          <xs:documentation>
+            <doc:description value="Country code"/>
+            <doc:condition name="C501"/>
+            <doc:codeList name="CountryCodesFullList" type="business"/>
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element minOccurs="0" name="NADLNGCE" type="simple:LanguageCodeType">
+        <xs:annotation>
+          <xs:documentation>
+            <doc:description value="NAD LNG"/>
+            <doc:rule name="TR0099"/>
+            <doc:codeList name="LanguageCodes" type="business"/>
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element minOccurs="0" name="TINCE159" type="simple:TINType">
+        <xs:annotation>
+          <xs:documentation>
+            <doc:description value="TIN"/>
+            <doc:rule name="R840"/>
+            <doc:condition name="C562"/>
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="NOTPAR670Type">
+    <xs:annotation>
+      <xs:documentation>
+        <doc:description value="NOTIFY PARTY"/>
+      </xs:documentation>
+    </xs:annotation>
+    <xs:sequence>
+      <xs:element minOccurs="0" name="NamNOTPAR672" type="simple:TradNameType">
+        <xs:annotation>
+          <xs:documentation>
+            <doc:description value="Name"/>
+            <doc:condition name="C501"/>
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element minOccurs="0" name="StrNumNOTPAR673" type="simple:StreetNumType">
+        <xs:annotation>
+          <xs:documentation>
+            <doc:description value="Street and number"/>
+            <doc:condition name="C501"/>
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element minOccurs="0" name="PosCodNOTPAR676" type="simple:PostalCodeType">
+        <xs:annotation>
+          <xs:documentation>
+            <doc:description value="Postal code"/>
+            <doc:condition name="C501"/>
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element minOccurs="0" name="CitNOTPAR674" type="simple:CityType">
+        <xs:annotation>
+          <xs:documentation>
+            <doc:description value="City"/>
+            <doc:condition name="C501"/>
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element minOccurs="0" name="CouCodNOTPAR675" type="simple:CountryCodeType">
+        <xs:annotation>
+          <xs:documentation>
+            <doc:description value="Country code"/>
+            <doc:condition name="C501"/>
+            <doc:codeList name="CountryCodesFullList" type="business"/>
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element minOccurs="0" name="NOTPAR670LNG" type="simple:LanguageCodeType">
+        <xs:annotation>
+          <xs:documentation>
+            <doc:description value="NAD LNG"/>
+            <doc:rule name="TR0099"/>
+            <doc:codeList name="LanguageCodes" type="business"/>
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element minOccurs="0" name="TINNOTPAR671" type="simple:TINType">
+        <xs:annotation>
+          <xs:documentation>
+            <doc:description value="TIN"/>
+            <doc:rule name="R840"/>
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="GOOITEGDSType">
+    <xs:annotation>
+      <xs:documentation>
+        <doc:description value="GOODS ITEM"/>
+      </xs:documentation>
+    </xs:annotation>
+    <xs:sequence>
+      <xs:element name="IteNumGDS7" type="simple:Numeric_Max5">
+        <xs:annotation>
+          <xs:documentation>
+            <doc:description value="Item number"/>
+            <doc:rule name="R005"/>
+            <doc:rule name="R007"/>
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element minOccurs="0" name="GooDesGDS23" type="simple:Alphanumeric_Max280">
+        <xs:annotation>
+          <xs:documentation>
+            <doc:description value="Goods description"/>
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element minOccurs="0" name="GooDesGDS23LNG" type="simple:LanguageCodeType">
+        <xs:annotation>
+          <xs:documentation>
+            <doc:description value="Goods description LNG"/>
+            <doc:rule name="TR0099"/>
+            <doc:codeList name="LanguageCodes" type="business"/>
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element minOccurs="0" name="GroMasGDS46" type="simple:Decimal_11_3">
+        <xs:annotation>
+          <xs:documentation>
+            <doc:description value="Gross mass"/>
+            <doc:condition name="C592"/>
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element minOccurs="0" name="MetOfPayGDI12" type="simple:AlphaCapital1Type">
+        <xs:annotation>
+          <xs:documentation>
+            <doc:description value="Transport charges/ Method of Payment"/>
+            <doc:condition name="C576"/>
+            <doc:codeList name="TransportChargesMethodOfPayment" type="business"/>
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element minOccurs="0" name="ComRefNumGIM1" type="simple:Alphanumeric_Max70">
+        <xs:annotation>
+          <xs:documentation>
+            <doc:description value="Commercial Reference Number"/>
+            <doc:condition name="C567"/>
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element minOccurs="0" name="UNDanGooCodGDI1" type="simple:Numeric_4">
+        <xs:annotation>
+          <xs:documentation>
+            <doc:description value="UN dangerous goods code"/>
+            <doc:rule name="R823"/>
+            <doc:codeList name="UnDangerousGoodsCode" type="business"/>
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element minOccurs="0" name="PlaLoaGOOITE333" type="simple:AlphanumericSpecMax35Type">
+        <xs:annotation>
+          <xs:documentation>
+            <doc:description value="Place of loading"/>
+            <doc:rule name="R670"/>
+            <doc:condition name="C574"/>
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element minOccurs="0" name="PlaLoaGOOITE333LNG" type="simple:LanguageCodeType">
+        <xs:annotation>
+          <xs:documentation>
+            <doc:description value="Place of loading LNG"/>
+            <doc:rule name="TR0099"/>
+            <doc:codeList name="LanguageCodes" type="business"/>
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element minOccurs="0" name="PlaUnlGOOITE333" type="simple:AlphanumericSpecMax35Type">
+        <xs:annotation>
+          <xs:documentation>
+            <doc:description value="Place of unloading"/>
+            <doc:rule name="R670"/>
+            <doc:condition name="C579"/>
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element minOccurs="0" name="PlaUnlGOOITE333LNG" type="simple:LanguageCodeType">
+        <xs:annotation>
+          <xs:documentation>
+            <doc:description value="Place of unloading LNG"/>
+            <doc:rule name="TR0099"/>
+            <doc:codeList name="LanguageCodes" type="business"/>
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element minOccurs="0" maxOccurs="99" name="PRODOCDC2" type="ie:PRODOCDC2Type">
+        <xs:annotation>
+          <xs:documentation>
+            <doc:description value="PRODUCED DOCUMENTS/CERTIFICATES"/>
+            <doc:rule name="R866"/>
+            <doc:condition name="C567"/>
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element minOccurs="0" maxOccurs="99" name="SPEMENMT2" type="complex_ics:SPEMENMT2Type">
+        <xs:annotation>
+          <xs:documentation>
+            <doc:description value="SPECIAL MENTIONS"/>
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element minOccurs="0" name="TRACONCO2" type="ie:TRACONCO2Type">
+        <xs:annotation>
+          <xs:documentation>
+            <doc:description value="(CONSIGNOR) TRADER"/>
+            <doc:condition name="C511"/>
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element minOccurs="0" name="COMCODGODITM" type="complex_ics:COMCODGODITMType">
+        <xs:annotation>
+          <xs:documentation>
+            <doc:description value="(CODE) COMMODITY"/>
+            <doc:condition name="C585"/>
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element minOccurs="0" name="TRACONCE2" type="ie:TRACONCE2Type">
+        <xs:annotation>
+          <xs:documentation>
+            <doc:description value="(CONSIGNEE) TRADER"/>
+            <doc:condition name="C584"/>
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element minOccurs="0" maxOccurs="99" name="CONNR2" type="ie:CONNR2Type">
+        <xs:annotation>
+          <xs:documentation>
+            <doc:description value="CONTAINERS"/>
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element minOccurs="0" maxOccurs="unbounded" name="IDEMEATRAGI970" type="ie:IDEMEATRAGI970Type">
+        <xs:annotation>
+          <xs:documentation>
+            <doc:description value="(MEANS OF TRANSPORT AT BORDER) IDENTITY"/>
+            <doc:condition name="C019"/>
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element minOccurs="0" maxOccurs="99" name="PACGS2" type="complex_ics:PACGS2Type">
+        <xs:annotation>
+          <xs:documentation>
+            <doc:description value="PACKAGES"/>
+            <doc:condition name="C577"/>
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element minOccurs="0" name="PRTNOT640" type="ie:PRTNOT640Type">
+        <xs:annotation>
+          <xs:documentation>
+            <doc:description value="NOTIFY PARTY"/>
+            <doc:condition name="C584"/>
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="PRODOCDC2Type">
+    <xs:annotation>
+      <xs:documentation>
+        <doc:description value="PRODUCED DOCUMENTS/CERTIFICATES"/>
+      </xs:documentation>
+    </xs:annotation>
+    <xs:sequence>
+      <xs:element name="DocTypDC21" type="simple:Alphanumeric_Max4">
+        <xs:annotation>
+          <xs:documentation>
+            <doc:description value="Document type"/>
+            <doc:rule name="R866"/>
+            <doc:codeList name="DocumentTypeCommon" type="business"/>
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="DocRefDC23" type="simple:Alphanumeric_Max35">
+        <xs:annotation>
+          <xs:documentation>
+            <doc:description value="Document reference"/>
+            <doc:rule name="R866"/>
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element minOccurs="0" name="DocRefDCLNG" type="simple:LanguageCodeType">
+        <xs:annotation>
+          <xs:documentation>
+            <doc:description value="Document reference LNG"/>
+            <doc:rule name="TR0099"/>
+            <doc:codeList name="LanguageCodes" type="business"/>
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="TRACONCO2Type">
+    <xs:annotation>
+      <xs:documentation>
+        <doc:description value="(CONSIGNOR) TRADER"/>
+      </xs:documentation>
+    </xs:annotation>
+    <xs:sequence>
+      <xs:element minOccurs="0" name="NamCO27" type="simple:TradNameType">
+        <xs:annotation>
+          <xs:documentation>
+            <doc:description value="Name"/>
+            <doc:condition name="C501"/>
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element minOccurs="0" name="StrAndNumCO222" type="simple:StreetNumType">
+        <xs:annotation>
+          <xs:documentation>
+            <doc:description value="Street and number"/>
+            <doc:condition name="C501"/>
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element minOccurs="0" name="PosCodCO223" type="simple:PostalCodeType">
+        <xs:annotation>
+          <xs:documentation>
+            <doc:description value="Postal code"/>
+            <doc:condition name="C501"/>
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element minOccurs="0" name="CitCO224" type="simple:CityType">
+        <xs:annotation>
+          <xs:documentation>
+            <doc:description value="City"/>
+            <doc:condition name="C501"/>
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element minOccurs="0" name="CouCO225" type="simple:CountryCodeType">
+        <xs:annotation>
+          <xs:documentation>
+            <doc:description value="Country code"/>
+            <doc:condition name="C501"/>
+            <doc:codeList name="CountryCodesFullList" type="business"/>
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element minOccurs="0" name="NADLNGGTCO" type="simple:LanguageCodeType">
+        <xs:annotation>
+          <xs:documentation>
+            <doc:description value="NAD LNG"/>
+            <doc:rule name="TR0099"/>
+            <doc:codeList name="LanguageCodes" type="business"/>
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element minOccurs="0" name="TINCO259" type="simple:TINType">
+        <xs:annotation>
+          <xs:documentation>
+            <doc:description value="TIN"/>
+            <doc:rule name="R840"/>
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="TRACONCE2Type">
+    <xs:annotation>
+      <xs:documentation>
+        <doc:description value="(CONSIGNEE) TRADER"/>
+      </xs:documentation>
+    </xs:annotation>
+    <xs:sequence>
+      <xs:element minOccurs="0" name="NamCE27" type="simple:TradNameType">
+        <xs:annotation>
+          <xs:documentation>
+            <doc:description value="Name"/>
+            <doc:condition name="C501"/>
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element minOccurs="0" name="StrAndNumCE222" type="simple:StreetNumType">
+        <xs:annotation>
+          <xs:documentation>
+            <doc:description value="Street and number"/>
+            <doc:condition name="C501"/>
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element minOccurs="0" name="PosCodCE223" type="simple:PostalCodeType">
+        <xs:annotation>
+          <xs:documentation>
+            <doc:description value="Postal code"/>
+            <doc:condition name="C501"/>
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element minOccurs="0" name="CitCE224" type="simple:CityType">
+        <xs:annotation>
+          <xs:documentation>
+            <doc:description value="City"/>
+            <doc:condition name="C501"/>
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element minOccurs="0" name="CouCE225" type="simple:CountryCodeType">
+        <xs:annotation>
+          <xs:documentation>
+            <doc:description value="Country code"/>
+            <doc:condition name="C501"/>
+            <doc:codeList name="CountryCodesFullList" type="business"/>
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element minOccurs="0" name="NADLNGGICE" type="simple:LanguageCodeType">
+        <xs:annotation>
+          <xs:documentation>
+            <doc:description value="NAD LNG"/>
+            <doc:rule name="TR0099"/>
+            <doc:codeList name="LanguageCodes" type="business"/>
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element minOccurs="0" name="TINCE259" type="simple:TINType">
+        <xs:annotation>
+          <xs:documentation>
+            <doc:description value="TIN"/>
+            <doc:rule name="R840"/>
+            <doc:condition name="C562"/>
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="CONNR2Type">
+    <xs:annotation>
+      <xs:documentation>
+        <doc:description value="CONTAINERS"/>
+      </xs:documentation>
+    </xs:annotation>
+    <xs:sequence>
+      <xs:element name="ConNumNR21" type="simple:Alphanumeric_Max17">
+        <xs:annotation>
+          <xs:documentation>
+            <doc:description value="Container number"/>
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="IDEMEATRAGI970Type">
+    <xs:annotation>
+      <xs:documentation>
+        <doc:description value="(MEANS OF TRANSPORT AT BORDER) IDENTITY"/>
+      </xs:documentation>
+    </xs:annotation>
+    <xs:sequence>
+      <xs:element minOccurs="0" name="NatIDEMEATRAGI973" type="simple:CountryCodeType">
+        <xs:annotation>
+          <xs:documentation>
+            <doc:description value="Nationality"/>
+            <doc:condition name="C020"/>
+            <doc:codeList name="CountryCodesFullList" type="business"/>
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="IdeMeaTraGIMEATRA971" type="simple:Alphanumeric_Max27">
+        <xs:annotation>
+          <xs:documentation>
+            <doc:description value="Identity of means of transport crossing border"/>
+            <doc:condition name="C514"/>
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element minOccurs="0" name="IdeMeaTraGIMEATRA972LNG" type="simple:LanguageCodeType">
+        <xs:annotation>
+          <xs:documentation>
+            <doc:description value="Identity of means of transport crossing border LNG"/>
+            <doc:rule name="TR0099"/>
+            <doc:codeList name="LanguageCodes" type="business"/>
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="PRTNOT640Type">
+    <xs:annotation>
+      <xs:documentation>
+        <doc:description value="NOTIFY PARTY"/>
+      </xs:documentation>
+    </xs:annotation>
+    <xs:sequence>
+      <xs:element minOccurs="0" name="NamPRTNOT642" type="simple:TradNameType">
+        <xs:annotation>
+          <xs:documentation>
+            <doc:description value="Name"/>
+            <doc:condition name="C501"/>
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element minOccurs="0" name="StrNumPRTNOT646" type="simple:StreetNumType">
+        <xs:annotation>
+          <xs:documentation>
+            <doc:description value="Street and number"/>
+            <doc:condition name="C501"/>
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element minOccurs="0" name="PstCodPRTNOT644" type="simple:PostalCodeType">
+        <xs:annotation>
+          <xs:documentation>
+            <doc:description value="Postal code"/>
+            <doc:condition name="C501"/>
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element minOccurs="0" name="CtyPRTNOT643" type="simple:CityType">
+        <xs:annotation>
+          <xs:documentation>
+            <doc:description value="City"/>
+            <doc:condition name="C501"/>
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element minOccurs="0" name="CouCodGINOT647" type="simple:CountryCodeType">
+        <xs:annotation>
+          <xs:documentation>
+            <doc:description value="Country code"/>
+            <doc:condition name="C501"/>
+            <doc:codeList name="CountryCodesFullList" type="business"/>
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element minOccurs="0" name="PRTNOT640LNG" type="simple:LanguageCodeType">
+        <xs:annotation>
+          <xs:documentation>
+            <doc:description value="NAD LNG"/>
+            <doc:rule name="TR0099"/>
+            <doc:codeList name="LanguageCodes" type="business"/>
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element minOccurs="0" name="TINPRTNOT641" type="simple:TINType">
+        <xs:annotation>
+          <xs:documentation>
+            <doc:description value="TIN"/>
+            <doc:rule name="R840"/>
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="CUSOFFLONType">
+    <xs:annotation>
+      <xs:documentation>
+        <doc:description value="(LODGEMENT) CUSTOMS OFFICE"/>
+      </xs:documentation>
+    </xs:annotation>
+    <xs:sequence>
+      <xs:element name="RefNumCOL1" type="simple:CORefNumType">
+        <xs:annotation>
+          <xs:documentation>
+            <doc:description value="Reference number"/>
+            <doc:rule name="R828"/>
+            <doc:rule name="R836"/>
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="TRAREPType">
+    <xs:annotation>
+      <xs:documentation>
+        <doc:description value="(REPRESENTATIVE) TRADER"/>
+      </xs:documentation>
+    </xs:annotation>
+    <xs:sequence>
+      <xs:element minOccurs="0" name="NamTRE1" type="simple:TradNameType">
+        <xs:annotation>
+          <xs:documentation>
+            <doc:description value="Name"/>
+            <doc:condition name="C501"/>
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element minOccurs="0" name="StrAndNumTRE1" type="simple:StreetNumType">
+        <xs:annotation>
+          <xs:documentation>
+            <doc:description value="Street and number"/>
+            <doc:condition name="C501"/>
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element minOccurs="0" name="PosCodTRE1" type="simple:PostalCodeType">
+        <xs:annotation>
+          <xs:documentation>
+            <doc:description value="Postal code"/>
+            <doc:condition name="C501"/>
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element minOccurs="0" name="CitTRE1" type="simple:CityType">
+        <xs:annotation>
+          <xs:documentation>
+            <doc:description value="City"/>
+            <doc:condition name="C501"/>
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element minOccurs="0" name="CouCodTRE1" type="simple:CountryCodeType">
+        <xs:annotation>
+          <xs:documentation>
+            <doc:description value="Country code"/>
+            <doc:condition name="C501"/>
+            <doc:codeList name="CountryCodesFullList" type="business"/>
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element minOccurs="0" name="TRAREPLNG" type="simple:LanguageCodeType">
+        <xs:annotation>
+          <xs:documentation>
+            <doc:description value="NAD LNG"/>
+            <doc:rule name="TR0099"/>
+            <doc:codeList name="LanguageCodes" type="business"/>
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="TINTRE1" type="simple:TINType">
+        <xs:annotation>
+          <xs:documentation>
+            <doc:description value="TIN"/>
+            <doc:rule name="R837"/>
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="PERLODSUMDECType">
+    <xs:annotation>
+      <xs:documentation>
+        <doc:description value="(LODGING SUMMARY DECLARATION) PERSON"/>
+      </xs:documentation>
+    </xs:annotation>
+    <xs:sequence>
+      <xs:element minOccurs="0" name="NamPLD1" type="simple:TradNameType">
+        <xs:annotation>
+          <xs:documentation>
+            <doc:description value="Name"/>
+            <doc:condition name="C501"/>
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element minOccurs="0" name="StrAndNumPLD1" type="simple:StreetNumType">
+        <xs:annotation>
+          <xs:documentation>
+            <doc:description value="Street and number"/>
+            <doc:condition name="C501"/>
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element minOccurs="0" name="PosCodPLD1" type="simple:PostalCodeType">
+        <xs:annotation>
+          <xs:documentation>
+            <doc:description value="Postal code"/>
+            <doc:condition name="C501"/>
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element minOccurs="0" name="CitPLD1" type="simple:CityType">
+        <xs:annotation>
+          <xs:documentation>
+            <doc:description value="City"/>
+            <doc:condition name="C501"/>
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element minOccurs="0" name="CouCodPLD1" type="simple:CountryCodeType">
+        <xs:annotation>
+          <xs:documentation>
+            <doc:description value="Country code"/>
+            <doc:condition name="C501"/>
+            <doc:codeList name="CountryCodesFullList" type="business"/>
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element minOccurs="0" name="PERLODSUMDECLNG" type="simple:LanguageCodeType">
+        <xs:annotation>
+          <xs:documentation>
+            <doc:description value="NAD LNG"/>
+            <doc:rule name="TR0099"/>
+            <doc:codeList name="LanguageCodes" type="business"/>
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="TINPLD1" type="simple:TINType">
+        <xs:annotation>
+          <xs:documentation>
+            <doc:description value="TIN"/>
+            <doc:rule name="R837"/>
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="CUSOFFFENT730Type">
+    <xs:annotation>
+      <xs:documentation>
+        <doc:description value="(FIRST ENTRY) CUSTOMS OFFICE"/>
+      </xs:documentation>
+    </xs:annotation>
+    <xs:sequence>
+      <xs:element name="RefNumCUSOFFFENT731" type="simple:CORefNumType">
+        <xs:annotation>
+          <xs:documentation>
+            <doc:description value="Reference number"/>
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="ExpDatOfArrFIRENT733" type="simple:DateTimeType">
+        <xs:annotation>
+          <xs:documentation>
+            <doc:description value="Expected date and time of arrival"/>
+            <doc:rule name="R660"/>
+            <doc:rule name="R666"/>
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="TRACARENT601Type">
+    <xs:annotation>
+      <xs:documentation>
+        <doc:description value="(ENTRY CARRIER) TRADER"/>
+      </xs:documentation>
+    </xs:annotation>
+    <xs:sequence>
+      <xs:element minOccurs="0" name="NamTRACARENT604" type="simple:TradNameType">
+        <xs:annotation>
+          <xs:documentation>
+            <doc:description value="Name"/>
+            <doc:condition name="C501"/>
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element minOccurs="0" name="StrNumTRACARENT607" type="simple:StreetNumType">
+        <xs:annotation>
+          <xs:documentation>
+            <doc:description value="Street and number"/>
+            <doc:condition name="C501"/>
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element minOccurs="0" name="PstCodTRACARENT606" type="simple:PostalCodeType">
+        <xs:annotation>
+          <xs:documentation>
+            <doc:description value="Postal code"/>
+            <doc:condition name="C501"/>
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element minOccurs="0" name="CtyTRACARENT603" type="simple:CityType">
+        <xs:annotation>
+          <xs:documentation>
+            <doc:description value="City"/>
+            <doc:condition name="C501"/>
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element minOccurs="0" name="CouCodTRACARENT605" type="simple:CountryCodeType">
+        <xs:annotation>
+          <xs:documentation>
+            <doc:description value="Country code"/>
+            <doc:condition name="C501"/>
+            <doc:codeList name="CountryCodesFullList" type="business"/>
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element minOccurs="0" name="TRACARENT601LNG" type="simple:LanguageCodeType">
+        <xs:annotation>
+          <xs:documentation>
+            <doc:description value="NAD LNG"/>
+            <doc:rule name="TR0099"/>
+            <doc:codeList name="LanguageCodes" type="business"/>
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element minOccurs="0" name="TINTRACARENT602" type="simple:TINType">
+        <xs:annotation>
+          <xs:documentation>
+            <doc:description value="TIN"/>
+            <doc:rule name="R840"/>
+            <doc:condition name="C502"/>
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+    </xs:sequence>
+  </xs:complexType>
+</xs:schema>

--- a/test/resources/schema/complex_types_ics-v11-2.xsd
+++ b/test/resources/schema/complex_types_ics-v11-2.xsd
@@ -1,0 +1,1754 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:complex_ics="http://ics.dgtaxud.ec/complex_ics" targetNamespace="http://ics.dgtaxud.ec/complex_ics" xmlns:doc="http://ics.dgtaxud.ec/doc" xmlns:simple="http://ics.dgtaxud.ec/simple" xmlns:tcl="http://ics.dgtaxud.ec/tcl" version="11.1" id="complex_types_ics" elementFormDefault="unqualified" attributeFormDefault="unqualified">
+  <xs:import namespace="http://ics.dgtaxud.ec/doc" schemaLocation="doc-v11-2.xsd"/>
+  <xs:import namespace="http://ics.dgtaxud.ec/simple" schemaLocation="simple_types-v11-2.xsd"/>
+  <xs:import namespace="http://ics.dgtaxud.ec/tcl" schemaLocation="tcl-v11-2.xsd"/>
+  <xs:complexType name="COICOSNType">
+    <xs:annotation>
+      <xs:documentation>
+        <doc:description value="CUSTOMS OFFICE SPECIFIC NOTES"/>
+      </xs:documentation>
+    </xs:annotation>
+    <xs:sequence>
+      <xs:element name="SpecNotCodCN634" type="simple:Alphanumeric_Max6">
+        <xs:annotation>
+          <xs:documentation>
+            <doc:description value="Specific notes code"/>
+            <doc:rule name="R486"/>
+            <doc:codeList name="SpecificNotesCode"/>
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="COMCODGIIMP249Type">
+    <xs:annotation>
+      <xs:documentation>
+        <doc:description value="(CODE) COMMODITY"/>
+      </xs:documentation>
+    </xs:annotation>
+    <xs:sequence>
+      <xs:element name="ComNomCOMCODGIIMP250" type="simple:NumericMin4Max8Type">
+        <xs:annotation>
+          <xs:documentation>
+            <doc:description value="Combined Nomenclature"/>
+            <doc:rule name="R881"/>
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="COMCODGODITMType">
+    <xs:annotation>
+      <xs:documentation>
+        <doc:description value="(CODE) COMMODITY"/>
+      </xs:documentation>
+    </xs:annotation>
+    <xs:sequence>
+      <xs:element name="ComNomCMD1" type="simple:NumericMin4Max8Type">
+        <xs:annotation>
+          <xs:documentation>
+            <doc:description value="Combined Nomenclature"/>
+            <doc:rule name="R881"/>
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="CONCEGIIMP251Type">
+    <xs:annotation>
+      <xs:documentation>
+        <doc:description value="(CONSIGNEE) TRADER"/>
+      </xs:documentation>
+    </xs:annotation>
+    <xs:sequence>
+      <xs:element minOccurs="0" name="NamCONCEGIIMP255" type="simple:TradNameType">
+        <xs:annotation>
+          <xs:documentation>
+            <doc:description value="Name"/>
+            <doc:rule name="R501"/>
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element minOccurs="0" name="StrAndNumCONCEGIIMP257" type="simple:StreetNumType">
+        <xs:annotation>
+          <xs:documentation>
+            <doc:description value="Street and number"/>
+            <doc:rule name="R501"/>
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element minOccurs="0" name="PosCodCONCEGIIMP256" type="simple:PostalCodeType">
+        <xs:annotation>
+          <xs:documentation>
+            <doc:description value="Postal code"/>
+            <doc:rule name="R501"/>
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element minOccurs="0" name="CouCodCONCEGIIMP253" type="simple:CountryCodeType">
+        <xs:annotation>
+          <xs:documentation>
+            <doc:description value="Country code"/>
+            <doc:rule name="R501"/>
+            <doc:codeList name="CountryCodesFullList"/>
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element minOccurs="0" name="CitCONCEGIIMP252" type="simple:CityType">
+        <xs:annotation>
+          <xs:documentation>
+            <doc:description value="City"/>
+            <doc:rule name="R501"/>
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element minOccurs="0" name="CONCEGIIMP251LNG" type="simple:LanguageCodeType">
+        <xs:annotation>
+          <xs:documentation>
+            <doc:description value="NAD LNG"/>
+            <doc:rule name="R501"/>
+            <doc:codeList name="LanguageCodes"/>
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element minOccurs="0" name="TINCONCEGIIMP258" type="simple:TINType">
+        <xs:annotation>
+          <xs:documentation>
+            <doc:description value="TIN"/>
+            <doc:rule name="R840"/>
+            <doc:condition name="C562"/>
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="CONCOGIIMP259Type">
+    <xs:annotation>
+      <xs:documentation>
+        <doc:description value="(CONSIGNOR) TRADER"/>
+      </xs:documentation>
+    </xs:annotation>
+    <xs:sequence>
+      <xs:element minOccurs="0" name="NamCONCOGIIMP263" type="simple:TradNameType">
+        <xs:annotation>
+          <xs:documentation>
+            <doc:description value="Name"/>
+            <doc:rule name="R501"/>
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element minOccurs="0" name="StrAndNumCONCOGIIMP265" type="simple:StreetNumType">
+        <xs:annotation>
+          <xs:documentation>
+            <doc:description value="Street and number"/>
+            <doc:rule name="R501"/>
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element minOccurs="0" name="PosCodCONCOGIIMP264" type="simple:PostalCodeType">
+        <xs:annotation>
+          <xs:documentation>
+            <doc:description value="Postal code"/>
+            <doc:rule name="R501"/>
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element minOccurs="0" name="CitCONCOGIIMP260" type="simple:CityType">
+        <xs:annotation>
+          <xs:documentation>
+            <doc:description value="City"/>
+            <doc:rule name="R501"/>
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element minOccurs="0" name="CouCodCONCOGIIMP261" type="simple:CountryCodeType">
+        <xs:annotation>
+          <xs:documentation>
+            <doc:description value="Country code"/>
+            <doc:rule name="R501"/>
+            <doc:codeList name="CountryCodesFullList"/>
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element minOccurs="0" name="CONCOGIIMP259LNG" type="simple:LanguageCodeType">
+        <xs:annotation>
+          <xs:documentation>
+            <doc:description value="NAD LNG"/>
+            <doc:rule name="R501"/>
+            <doc:codeList name="LanguageCodes"/>
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element minOccurs="0" name="TINCONCOGIIMP266" type="simple:TINType">
+        <xs:annotation>
+          <xs:documentation>
+            <doc:description value="TIN"/>
+            <doc:rule name="R840"/>
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="CONCOTRAIMP208Type">
+    <xs:annotation>
+      <xs:documentation>
+        <doc:description value="(CONSIGNOR) TRADER"/>
+      </xs:documentation>
+    </xs:annotation>
+    <xs:sequence>
+      <xs:element minOccurs="0" name="NamCONCOTRAIMP212" type="simple:TradNameType">
+        <xs:annotation>
+          <xs:documentation>
+            <doc:description value="Name"/>
+            <doc:rule name="R501"/>
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element minOccurs="0" name="StrAndNumCONCOTRAIMP214" type="simple:StreetNumType">
+        <xs:annotation>
+          <xs:documentation>
+            <doc:description value="Street and number"/>
+            <doc:rule name="R501"/>
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element minOccurs="0" name="PosCodCONCOTRAIMP213" type="simple:PostalCodeType">
+        <xs:annotation>
+          <xs:documentation>
+            <doc:description value="Postal code"/>
+            <doc:rule name="R501"/>
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element minOccurs="0" name="CitCONCOTRAIMP209" type="simple:CityType">
+        <xs:annotation>
+          <xs:documentation>
+            <doc:description value="City"/>
+            <doc:rule name="R501"/>
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element minOccurs="0" name="CouCodCONCOTRAIMP210" type="simple:CountryCodeType">
+        <xs:annotation>
+          <xs:documentation>
+            <doc:description value="Country code"/>
+            <doc:rule name="R501"/>
+            <doc:codeList name="CountryCodesFullList"/>
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element minOccurs="0" name="CONCOTRAIMP208LNG" type="simple:LanguageCodeType">
+        <xs:annotation>
+          <xs:documentation>
+            <doc:description value="NAD LNG"/>
+            <doc:rule name="R501"/>
+            <doc:codeList name="LanguageCodes"/>
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element minOccurs="0" name="TINCONCOTRAIMP215" type="simple:TINType">
+        <xs:annotation>
+          <xs:documentation>
+            <doc:description value="TIN"/>
+            <doc:rule name="R840"/>
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="CONGIIMP272Type">
+    <xs:annotation>
+      <xs:documentation>
+        <doc:description value="CONTAINERS"/>
+      </xs:documentation>
+    </xs:annotation>
+    <xs:sequence>
+      <xs:element name="ConNumCONGIIMP273" type="simple:Alphanumeric_Max17">
+        <xs:annotation>
+          <xs:documentation>
+            <doc:description value="Container number"/>
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="CONTRAIMP200Type">
+    <xs:annotation>
+      <xs:documentation>
+        <doc:description value="(CONSIGNEE) TRADER"/>
+      </xs:documentation>
+    </xs:annotation>
+    <xs:sequence>
+      <xs:element minOccurs="0" name="NamCONTRAIMP204" type="simple:TradNameType">
+        <xs:annotation>
+          <xs:documentation>
+            <doc:description value="Name"/>
+            <doc:rule name="R501"/>
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element minOccurs="0" name="StrAndNumCONTRAIMP206" type="simple:StreetNumType">
+        <xs:annotation>
+          <xs:documentation>
+            <doc:description value="Street and number"/>
+            <doc:rule name="R501"/>
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element minOccurs="0" name="PosCodCONTRAIMP205" type="simple:PostalCodeType">
+        <xs:annotation>
+          <xs:documentation>
+            <doc:description value="Postal code"/>
+            <doc:rule name="R501"/>
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element minOccurs="0" name="CitCONTRAIMP201" type="simple:CityType">
+        <xs:annotation>
+          <xs:documentation>
+            <doc:description value="City"/>
+            <doc:rule name="R501"/>
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element minOccurs="0" name="CouCodCONTRAIMP202" type="simple:CountryCodeType">
+        <xs:annotation>
+          <xs:documentation>
+            <doc:description value="Country code"/>
+            <doc:rule name="R501"/>
+            <doc:codeList name="CountryCodesFullList"/>
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element minOccurs="0" name="CONTRAIMP200LNG" type="simple:LanguageCodeType">
+        <xs:annotation>
+          <xs:documentation>
+            <doc:description value="NAD LNG"/>
+            <doc:rule name="R501"/>
+            <doc:codeList name="LanguageCodes"/>
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element minOccurs="0" name="TINCONTRAIMP207" type="simple:TINType">
+        <xs:annotation>
+          <xs:documentation>
+            <doc:description value="TIN"/>
+            <doc:rule name="R840"/>
+            <doc:condition name="C562"/>
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="COUHOLDATLSD121Type">
+    <xs:annotation>
+      <xs:documentation>
+        <doc:description value="COUNTRY HOLIDAYS DATA LSD"/>
+      </xs:documentation>
+    </xs:annotation>
+    <xs:sequence>
+      <xs:element name="LanCod102" type="simple:LanguageCodeType">
+        <xs:annotation>
+          <xs:documentation>
+            <doc:description value="Language code"/>
+            <doc:codeList name="LanguageCodes"/>
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="PubHolNam89" type="simple:Alphanumeric_Max35">
+        <xs:annotation>
+          <xs:documentation>
+            <doc:description value="Public holiday name"/>
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element minOccurs="0" name="PubHolNam89LNG" type="simple:LanguageCodeType">
+        <xs:annotation>
+          <xs:documentation>
+            <doc:description value="Public holiday name LNG"/>
+            <doc:rule name="TR0099"/>
+            <doc:codeList name="LanguageCodes"/>
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="COUHOLLSD117Type">
+    <xs:annotation>
+      <xs:documentation>
+        <doc:description value="COUNTRY/REGION HOLIDAYS LSD"/>
+      </xs:documentation>
+    </xs:annotation>
+    <xs:sequence>
+      <xs:element name="LanCod88" type="simple:LanguageCodeType">
+        <xs:annotation>
+          <xs:documentation>
+            <doc:description value="Language code"/>
+            <doc:codeList name="LanguageCodes"/>
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="PubHolNam89" type="simple:Alphanumeric_Max35">
+        <xs:annotation>
+          <xs:documentation>
+            <doc:description value="Public holiday name"/>
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element minOccurs="0" name="PubHolNam89LNG" type="simple:LanguageCodeType">
+        <xs:annotation>
+          <xs:documentation>
+            <doc:description value="Public holiday name LNG"/>
+            <doc:rule name="TR0099"/>
+            <doc:codeList name="LanguageCodes"/>
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="COULSD115Type">
+    <xs:annotation>
+      <xs:documentation>
+        <doc:description value="COUNTRY/REGION LSD"/>
+      </xs:documentation>
+    </xs:annotation>
+    <xs:sequence>
+      <xs:element name="LanCod80" type="simple:LanguageCodeType">
+        <xs:annotation>
+          <xs:documentation>
+            <doc:description value="Language code"/>
+            <doc:codeList name="LanguageCodes"/>
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="CouNam81" type="simple:Alphanumeric_Max35">
+        <xs:annotation>
+          <xs:documentation>
+            <doc:description value="Country/region name"/>
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element minOccurs="0" name="CouNam81LNG" type="simple:LanguageCodeType">
+        <xs:annotation>
+          <xs:documentation>
+            <doc:description value="Country/region name LNG"/>
+            <doc:rule name="TR0099"/>
+            <doc:codeList name="LanguageCodes"/>
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="COUNAVMATType">
+    <xs:annotation>
+      <xs:documentation>
+        <doc:description value="UNAVAILABILITY MATRIX"/>
+      </xs:documentation>
+    </xs:annotation>
+    <xs:sequence>
+      <xs:element name="CouUnaMatFrom670" type="simple:DateTimeType">
+        <xs:annotation>
+          <xs:documentation>
+            <doc:description value="Time from"/>
+            <doc:rule name="R660"/>
+            <doc:rule name="TR0105"/>
+            <doc:rule name="TR0107"/>
+            <doc:rule name="TR9020"/>
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="CouUnaMatTo671" type="simple:DateTimeType">
+        <xs:annotation>
+          <xs:documentation>
+            <doc:description value="Time to"/>
+            <doc:rule name="R660"/>
+            <doc:rule name="TR0105"/>
+            <doc:rule name="TR9020"/>
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="CUSOFFENTACTOFF700Type">
+    <xs:annotation>
+      <xs:documentation>
+        <doc:description value="(ACTUAL OFFICE OF ENTRY) CUSTOMS OFFICE"/>
+      </xs:documentation>
+    </xs:annotation>
+    <xs:sequence>
+      <xs:element name="RefNumCUSOFFENTACTOFF701" type="simple:CORefNumType">
+        <xs:annotation>
+          <xs:documentation>
+            <doc:description value="Reference number"/>
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="CUSOFFLSD109Type">
+    <xs:annotation>
+      <xs:documentation>
+        <doc:description value="CUSTOMS OFFICE LSD"/>
+      </xs:documentation>
+    </xs:annotation>
+    <xs:sequence>
+      <xs:element name="LanCod44" type="simple:LanguageCodeType">
+        <xs:annotation>
+          <xs:documentation>
+            <doc:description value="Language code"/>
+            <doc:codeList name="LanguageCodes"/>
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="CusOffUsuNam45" type="simple:Alphanumeric_Max35">
+        <xs:annotation>
+          <xs:documentation>
+            <doc:description value="Customs office usual name"/>
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element minOccurs="0" name="CusOffUsuNam45LNG" type="simple:LanguageCodeType">
+        <xs:annotation>
+          <xs:documentation>
+            <doc:description value="Customs office usual name LNG"/>
+            <doc:rule name="TR0099"/>
+            <doc:codeList name="LanguageCodes"/>
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="StrAndNum47" type="simple:StreetNumType">
+        <xs:annotation>
+          <xs:documentation>
+            <doc:description value="Street and number"/>
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element minOccurs="0" name="StrAndNum47LNG" type="simple:LanguageCodeType">
+        <xs:annotation>
+          <xs:documentation>
+            <doc:description value="Street and number LNG"/>
+            <doc:rule name="TR0099"/>
+            <doc:codeList name="LanguageCodes"/>
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="Cit49" type="simple:CityType">
+        <xs:annotation>
+          <xs:documentation>
+            <doc:description value="City"/>
+            <doc:rule name="R422"/>
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element minOccurs="0" name="Cit49LNG" type="simple:LanguageCodeType">
+        <xs:annotation>
+          <xs:documentation>
+            <doc:description value="City LNG"/>
+            <doc:rule name="TR0099"/>
+            <doc:codeList name="LanguageCodes"/>
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element minOccurs="0" name="PreLev51" type="tcl:PrefixSuffixLevel">
+        <xs:annotation>
+          <xs:documentation>
+            <doc:description value="Prefix-suffix level"/>
+            <doc:codeList name="PrefixSuffixLevel"/>
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="PreFla52" type="tcl:Flag">
+        <xs:annotation>
+          <xs:documentation>
+            <doc:description value="Prefix-suffix flag"/>
+            <doc:codeList name="Flag"/>
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element minOccurs="0" name="PreNam53" type="simple:Alphanumeric_Max35">
+        <xs:annotation>
+          <xs:documentation>
+            <doc:description value="Prefix-suffix name"/>
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element minOccurs="0" name="PreNam53LNG" type="simple:LanguageCodeType">
+        <xs:annotation>
+          <xs:documentation>
+            <doc:description value="Prefix-suffix name LNG"/>
+            <doc:rule name="TR0099"/>
+            <doc:codeList name="LanguageCodes"/>
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="Spa55" type="tcl:Flag">
+        <xs:annotation>
+          <xs:documentation>
+            <doc:description value="Space to add"/>
+            <doc:codeList name="Flag"/>
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="CUSOFFREQType">
+    <xs:annotation>
+      <xs:documentation>
+        <doc:description value="(REQUESTER) CUSTOMS OFFICE"/>
+      </xs:documentation>
+    </xs:annotation>
+    <xs:sequence>
+      <xs:element name="RefNumEPR1" type="simple:CORefNumType">
+        <xs:annotation>
+          <xs:documentation>
+            <doc:description value="Reference number"/>
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="CUSOFFROLCOM112Type">
+    <xs:annotation>
+      <xs:documentation>
+        <doc:description value="CUSTOMS OFFICE ROLE / TRAFFIC COMPETENCE"/>
+      </xs:documentation>
+    </xs:annotation>
+    <xs:sequence>
+      <xs:element name="Rol70" type="simple:Alpha_3">
+        <xs:annotation>
+          <xs:documentation>
+            <doc:description value="Role"/>
+            <doc:codeList name="Role"/>
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="TraTyp71" type="simple:Alphanumeric_Max3">
+        <xs:annotation>
+          <xs:documentation>
+            <doc:description value="Traffic type"/>
+            <doc:codeList name="TrafficType"/>
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="CUSOFFSENT740Type">
+    <xs:annotation>
+      <xs:documentation>
+        <doc:description value="(SUBSEQUENT ENTRY) CUSTOMS OFFICE"/>
+      </xs:documentation>
+    </xs:annotation>
+    <xs:sequence>
+      <xs:element name="RefNumSUBENR909" type="simple:CORefNumType">
+        <xs:annotation>
+          <xs:documentation>
+            <doc:description value="Reference number"/>
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="ENTCARTRAIMP216Type">
+    <xs:annotation>
+      <xs:documentation>
+        <doc:description value="(ENTRY CARRIER) TRADER"/>
+      </xs:documentation>
+    </xs:annotation>
+    <xs:sequence>
+      <xs:element minOccurs="0" name="NamENTCARTRAIMP220" type="simple:TradNameType">
+        <xs:annotation>
+          <xs:documentation>
+            <doc:description value="Name"/>
+            <doc:rule name="R501"/>
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element minOccurs="0" name="SrtAndNumENTCARTRAIMP222" type="simple:StreetNumType">
+        <xs:annotation>
+          <xs:documentation>
+            <doc:description value="Street and number"/>
+            <doc:rule name="R501"/>
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element minOccurs="0" name="PosCodENTCARTRAIMP221" type="simple:PostalCodeType">
+        <xs:annotation>
+          <xs:documentation>
+            <doc:description value="Postal code"/>
+            <doc:rule name="R501"/>
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element minOccurs="0" name="CitENTCARTRAIMP217" type="simple:CityType">
+        <xs:annotation>
+          <xs:documentation>
+            <doc:description value="City"/>
+            <doc:rule name="R501"/>
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element minOccurs="0" name="CouCodENTCARTRAIMP218" type="simple:CountryCodeType">
+        <xs:annotation>
+          <xs:documentation>
+            <doc:description value="Country code"/>
+            <doc:rule name="R501"/>
+            <doc:codeList name="CountryCodesFullList"/>
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element minOccurs="0" name="ENTCARTRAIMP216LNG" type="simple:LanguageCodeType">
+        <xs:annotation>
+          <xs:documentation>
+            <doc:description value="NAD LNG"/>
+            <doc:rule name="R501"/>
+            <doc:codeList name="LanguageCodes"/>
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element minOccurs="0" name="TINENTCARTRAIMP223" type="simple:TINType">
+        <xs:annotation>
+          <xs:documentation>
+            <doc:description value="TIN"/>
+            <doc:rule name="R840"/>
+            <doc:condition name="C502"/>
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="FIRENTCUSOFFIMP224Type">
+    <xs:annotation>
+      <xs:documentation>
+        <doc:description value="(FIRST ENTRY) CUSTOMS OFFICE"/>
+      </xs:documentation>
+    </xs:annotation>
+    <xs:sequence>
+      <xs:element name="RefNumFIRENTCUSOFFIMP226" type="simple:CORefNumType">
+        <xs:annotation>
+          <xs:documentation>
+            <doc:description value="Reference number"/>
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="ExpDatTimFIRENTCUSOFFIMP225" type="simple:DateTimeType">
+        <xs:annotation>
+          <xs:documentation>
+            <doc:description value="Expected date and time of arrival"/>
+            <doc:rule name="R660"/>
+            <doc:rule name="R666"/>
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="ITIIMP304Type">
+    <xs:annotation>
+      <xs:documentation>
+        <doc:description value="ITINERARY"/>
+      </xs:documentation>
+    </xs:annotation>
+    <xs:sequence>
+      <xs:element name="CouOfRouCodITIIMP305" type="simple:CountryCodeType">
+        <xs:annotation>
+          <xs:documentation>
+            <doc:description value="Country of routing code"/>
+            <doc:codeList name="CountryCodesFullList"/>
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="ITIType">
+    <xs:annotation>
+      <xs:documentation>
+        <doc:description value="ITINERARY"/>
+      </xs:documentation>
+    </xs:annotation>
+    <xs:sequence>
+      <xs:element name="CouOfRouCodITI1" type="simple:CountryCodeType">
+        <xs:annotation>
+          <xs:documentation>
+            <doc:description value="Country of routing code"/>
+            <doc:codeList name="CountryCodesFullList"/>
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="LODGCUSOFFIMP227Type">
+    <xs:annotation>
+      <xs:documentation>
+        <doc:description value="(LODGEMENT) CUSTOMS OFFICE"/>
+      </xs:documentation>
+    </xs:annotation>
+    <xs:sequence>
+      <xs:element name="RefNumLODGCUSOFFIMP228" type="simple:CORefNumType">
+        <xs:annotation>
+          <xs:documentation>
+            <doc:description value="Reference number"/>
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="LODSUMDECPERIMP229Type">
+    <xs:annotation>
+      <xs:documentation>
+        <doc:description value="(LODGING SUMMARY DECLARATION) PERSON"/>
+      </xs:documentation>
+    </xs:annotation>
+    <xs:sequence>
+      <xs:element minOccurs="0" name="NamLODSUMDECPERIMP233" type="simple:TradNameType">
+        <xs:annotation>
+          <xs:documentation>
+            <doc:description value="Name"/>
+            <doc:rule name="R501"/>
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element minOccurs="0" name="StrAndNumLODSUMDECPERIMP235" type="simple:StreetNumType">
+        <xs:annotation>
+          <xs:documentation>
+            <doc:description value="Street and number"/>
+            <doc:rule name="R501"/>
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element minOccurs="0" name="PosCodLODSUMDECPERIMP234" type="simple:PostalCodeType">
+        <xs:annotation>
+          <xs:documentation>
+            <doc:description value="Postal code"/>
+            <doc:rule name="R501"/>
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element minOccurs="0" name="CitLODSUMDECPERIMP230" type="simple:CityType">
+        <xs:annotation>
+          <xs:documentation>
+            <doc:description value="City"/>
+            <doc:rule name="R501"/>
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element minOccurs="0" name="CouCodLODSUMDECPERIMP231" type="simple:CountryCodeType">
+        <xs:annotation>
+          <xs:documentation>
+            <doc:description value="Country code"/>
+            <doc:rule name="R501"/>
+            <doc:codeList name="CountryCodesFullList"/>
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element minOccurs="0" name="LODSUMDECPERIMP229LNG" type="simple:LanguageCodeType">
+        <xs:annotation>
+          <xs:documentation>
+            <doc:description value="NAD LNG"/>
+            <doc:rule name="R501"/>
+            <doc:codeList name="LanguageCodes"/>
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="TINLODSUMDECPERIMP236" type="simple:TINType">
+        <xs:annotation>
+          <xs:documentation>
+            <doc:description value="TIN"/>
+            <doc:rule name="R837"/>
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="MEATRABOAGIIMP800Type">
+    <xs:annotation>
+      <xs:documentation>
+        <doc:description value="(MEANS OF TRANSPORT AT BORDER) IDENTITY"/>
+      </xs:documentation>
+    </xs:annotation>
+    <xs:sequence>
+      <xs:element name="IdeMeaTraMEATRABOAGIIMP801" type="simple:Alphanumeric_Max27">
+        <xs:annotation>
+          <xs:documentation>
+            <doc:description value="Identity of means of transport crossing border"/>
+            <doc:condition name="C514"/>
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element minOccurs="0" name="IdeMeaTraMEATRABOAGIIMP802LNG" type="simple:LanguageCodeType">
+        <xs:annotation>
+          <xs:documentation>
+            <doc:description value="Identity of means of transport crossing border LNG"/>
+            <doc:rule name="TR0099"/>
+            <doc:codeList name="LanguageCodes"/>
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element minOccurs="0" name="NatIdeMeaTraMEATRABOAGIIMP803" type="simple:CountryCodeType">
+        <xs:annotation>
+          <xs:documentation>
+            <doc:description value="Nationality"/>
+            <doc:condition name="C020"/>
+            <doc:codeList name="CountryCodesFullList"/>
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="NOTPARGIIMP274Type">
+    <xs:annotation>
+      <xs:documentation>
+        <doc:description value="NOTIFY PARTY"/>
+      </xs:documentation>
+    </xs:annotation>
+    <xs:sequence>
+      <xs:element minOccurs="0" name="NamNOTPARGIIMP277" type="simple:TradNameType">
+        <xs:annotation>
+          <xs:documentation>
+            <doc:description value="Name"/>
+            <doc:rule name="R501"/>
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element minOccurs="0" name="StrAndNumNOTPARGIIMP279" type="simple:StreetNumType">
+        <xs:annotation>
+          <xs:documentation>
+            <doc:description value="Street and number"/>
+            <doc:rule name="R501"/>
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element minOccurs="0" name="PosCodNOTPARGIIMP278" type="simple:PostalCodeType">
+        <xs:annotation>
+          <xs:documentation>
+            <doc:description value="Postal code"/>
+            <doc:rule name="R501"/>
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element minOccurs="0" name="CitNOTPARGIIMP400" type="simple:CityType">
+        <xs:annotation>
+          <xs:documentation>
+            <doc:description value="City"/>
+            <doc:rule name="R501"/>
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element minOccurs="0" name="CouCodNOTPARGIIMP275" type="simple:CountryCodeType">
+        <xs:annotation>
+          <xs:documentation>
+            <doc:description value="Country code"/>
+            <doc:rule name="R501"/>
+            <doc:codeList name="CountryCodesFullList"/>
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element minOccurs="0" name="NOTPARGIIMP274LNG" type="simple:LanguageCodeType">
+        <xs:annotation>
+          <xs:documentation>
+            <doc:description value="NAD LNG"/>
+            <doc:rule name="R501"/>
+            <doc:codeList name="LanguageCodes"/>
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element minOccurs="0" name="TINNOTPARGIIMP280" type="simple:TINType">
+        <xs:annotation>
+          <xs:documentation>
+            <doc:description value="TIN"/>
+            <doc:rule name="R840"/>
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="NOTPARIMP306Type">
+    <xs:annotation>
+      <xs:documentation>
+        <doc:description value="NOTIFY PARTY"/>
+      </xs:documentation>
+    </xs:annotation>
+    <xs:sequence>
+      <xs:element minOccurs="0" name="NamNOTPARIMP310" type="simple:TradNameType">
+        <xs:annotation>
+          <xs:documentation>
+            <doc:description value="Name"/>
+            <doc:rule name="R501"/>
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element minOccurs="0" name="StrAndNumNOTPARIMP312" type="simple:StreetNumType">
+        <xs:annotation>
+          <xs:documentation>
+            <doc:description value="Street and number"/>
+            <doc:rule name="R501"/>
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element minOccurs="0" name="PosCodNOTPARIMP311" type="simple:PostalCodeType">
+        <xs:annotation>
+          <xs:documentation>
+            <doc:description value="Postal code"/>
+            <doc:rule name="R501"/>
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element minOccurs="0" name="CitNOTPARIMP307" type="simple:CityType">
+        <xs:annotation>
+          <xs:documentation>
+            <doc:description value="City"/>
+            <doc:rule name="R501"/>
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element minOccurs="0" name="CouCodNOTPARIMP308" type="simple:CountryCodeType">
+        <xs:annotation>
+          <xs:documentation>
+            <doc:description value="Country code"/>
+            <doc:rule name="R501"/>
+            <doc:codeList name="CountryCodesFullList"/>
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element minOccurs="0" name="NOTPARIMP306LNG" type="simple:LanguageCodeType">
+        <xs:annotation>
+          <xs:documentation>
+            <doc:description value="NAD LNG"/>
+            <doc:rule name="R501"/>
+            <doc:codeList name="LanguageCodes"/>
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element minOccurs="0" name="TINNOTPARIMP313" type="simple:TINType">
+        <xs:annotation>
+          <xs:documentation>
+            <doc:description value="TIN"/>
+            <doc:rule name="R840"/>
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="PACGIIMP281Type">
+    <xs:annotation>
+      <xs:documentation>
+        <doc:description value="PACKAGES"/>
+      </xs:documentation>
+    </xs:annotation>
+    <xs:sequence>
+      <xs:element name="KinOfPacPACGIIMP282" type="simple:Alphanumeric_2">
+        <xs:annotation>
+          <xs:documentation>
+            <doc:description value="Kind of packages"/>
+            <doc:codeList name="KindOfPackages"/>
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element minOccurs="0" name="NumOfPacPACGIIMP285" type="simple:Numeric_Max5">
+        <xs:annotation>
+          <xs:documentation>
+            <doc:description value="Number of packages"/>
+            <doc:rule name="R021"/>
+            <doc:rule name="TR0022"/>
+            <doc:condition name="C062"/>
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element minOccurs="0" name="NumOfPiePACGIIMP286" type="simple:Numeric_Max5">
+        <xs:annotation>
+          <xs:documentation>
+            <doc:description value="Number of pieces"/>
+            <doc:condition name="C062"/>
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element minOccurs="0" name="MArAndNumPACGIIMPL283" type="simple:Alphanumeric_Max140">
+        <xs:annotation>
+          <xs:documentation>
+            <doc:description value="Marks &amp; numbers of packages (long)"/>
+            <doc:condition name="C062"/>
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element minOccurs="0" name="MarAndNumPACGIIMPL284LNG" type="simple:LanguageCodeType">
+        <xs:annotation>
+          <xs:documentation>
+            <doc:description value="Marks &amp; numbers of packages (long) LNG"/>
+            <doc:rule name="TR0099"/>
+            <doc:codeList name="LanguageCodes"/>
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="PACGS2Type">
+    <xs:annotation>
+      <xs:documentation>
+        <doc:description value="PACKAGES"/>
+      </xs:documentation>
+    </xs:annotation>
+    <xs:sequence>
+      <xs:element name="KinOfPacGS23" type="simple:Alphanumeric_2">
+        <xs:annotation>
+          <xs:documentation>
+            <doc:description value="Kind of packages"/>
+            <doc:codeList name="KindOfPackages"/>
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element minOccurs="0" name="NumOfPacGS24" type="simple:Numeric_Max5">
+        <xs:annotation>
+          <xs:documentation>
+            <doc:description value="Number of packages"/>
+            <doc:rule name="R021"/>
+            <doc:rule name="TR0022"/>
+            <doc:condition name="C062"/>
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element minOccurs="0" name="NumOfPieGS25" type="simple:Numeric_Max5">
+        <xs:annotation>
+          <xs:documentation>
+            <doc:description value="Number of pieces"/>
+            <doc:condition name="C062"/>
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element minOccurs="0" name="MarNumOfPacGSL21" type="simple:Alphanumeric_Max140">
+        <xs:annotation>
+          <xs:documentation>
+            <doc:description value="Marks &amp; numbers of packages (long)"/>
+            <doc:condition name="C062"/>
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element minOccurs="0" name="MarNumOfPacGSL21LNG" type="simple:LanguageCodeType">
+        <xs:annotation>
+          <xs:documentation>
+            <doc:description value="Marks &amp; numbers of packages (long) LNG"/>
+            <doc:rule name="TR0099"/>
+            <doc:codeList name="LanguageCodes"/>
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="PRODOCCERGIIMP287Type">
+    <xs:annotation>
+      <xs:documentation>
+        <doc:description value="PRODUCED DOCUMENTS/CERTIFICATES"/>
+      </xs:documentation>
+    </xs:annotation>
+    <xs:sequence>
+      <xs:element name="DocTypPRODOCCERGIIMP290" type="simple:Alphanumeric_Max4">
+        <xs:annotation>
+          <xs:documentation>
+            <doc:description value="Document type"/>
+            <doc:rule name="R866"/>
+            <doc:codeList name="DocumentTypeCommon"/>
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="DocRefPRODOCCERGIIMP288" type="simple:Alphanumeric_Max35">
+        <xs:annotation>
+          <xs:documentation>
+            <doc:description value="Document reference"/>
+            <doc:rule name="R866"/>
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element minOccurs="0" name="DocRefPRODOCCERGIIMP289LNG" type="simple:LanguageCodeType">
+        <xs:annotation>
+          <xs:documentation>
+            <doc:description value="Document reference LNG"/>
+            <doc:rule name="TR0099"/>
+            <doc:codeList name="LanguageCodes"/>
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="REPTRAIMP237Type">
+    <xs:annotation>
+      <xs:documentation>
+        <doc:description value="(REPRESENTATIVE) TRADER"/>
+      </xs:documentation>
+    </xs:annotation>
+    <xs:sequence>
+      <xs:element minOccurs="0" name="NamREPTRAIMP241" type="simple:TradNameType">
+        <xs:annotation>
+          <xs:documentation>
+            <doc:description value="Name"/>
+            <doc:rule name="R501"/>
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element minOccurs="0" name="StrAndNumREPTRAIMP243" type="simple:StreetNumType">
+        <xs:annotation>
+          <xs:documentation>
+            <doc:description value="Street and number"/>
+            <doc:rule name="R501"/>
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element minOccurs="0" name="PosCodREPTRAIMP242" type="simple:PostalCodeType">
+        <xs:annotation>
+          <xs:documentation>
+            <doc:description value="Postal code"/>
+            <doc:rule name="R501"/>
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element minOccurs="0" name="CitREPTRAIMP238" type="simple:CityType">
+        <xs:annotation>
+          <xs:documentation>
+            <doc:description value="City"/>
+            <doc:rule name="R501"/>
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element minOccurs="0" name="CouCodREPTRAIMP239" type="simple:CountryCodeType">
+        <xs:annotation>
+          <xs:documentation>
+            <doc:description value="Country code"/>
+            <doc:rule name="R501"/>
+            <doc:codeList name="CountryCodesFullList"/>
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element minOccurs="0" name="REPTRAIMP237LNG" type="simple:LanguageCodeType">
+        <xs:annotation>
+          <xs:documentation>
+            <doc:description value="NAD LNG"/>
+            <doc:rule name="R501"/>
+            <doc:codeList name="LanguageCodes"/>
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="TINREPTRAIMP244" type="simple:TINType">
+        <xs:annotation>
+          <xs:documentation>
+            <doc:description value="TIN"/>
+            <doc:rule name="R837"/>
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="RISANAIMP314Type">
+    <xs:annotation>
+      <xs:documentation>
+        <doc:description value="RISK ANALYSIS"/>
+      </xs:documentation>
+    </xs:annotation>
+    <xs:sequence>
+      <xs:element minOccurs="0" name="IteNumInvRISANAIMP315" type="simple:Numeric_Max5">
+        <xs:annotation>
+          <xs:documentation>
+            <doc:description value="Item Number involved"/>
+            <doc:rule name="R824"/>
+            <doc:rule name="R875"/>
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="RisAnaResCodRISANAIMP317" type="simple:Alphanumeric_Max5">
+        <xs:annotation>
+          <xs:documentation>
+            <doc:description value="Risk Analysis result code"/>
+            <doc:rule name="TR9175"/>
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element minOccurs="0" name="RisAnaTexRISANAIMP318" type="simple:Alphanumeric_Max350">
+        <xs:annotation>
+          <xs:documentation>
+            <doc:description value="Risk Analysis text"/>
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element minOccurs="0" name="RisAnaRISANAIMP316LNG" type="simple:LanguageCodeType">
+        <xs:annotation>
+          <xs:documentation>
+            <doc:description value="Risk Analysis LNG"/>
+            <doc:rule name="TR0099"/>
+            <doc:codeList name="LanguageCodes"/>
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="RISANAType">
+    <xs:annotation>
+      <xs:documentation>
+        <doc:description value="RISK ANALYSIS"/>
+      </xs:documentation>
+    </xs:annotation>
+    <xs:sequence>
+      <xs:element minOccurs="0" name="IteNumInvRKA1" type="simple:Numeric_Max5">
+        <xs:annotation>
+          <xs:documentation>
+            <doc:description value="Item Number involved"/>
+            <doc:rule name="R824"/>
+            <doc:rule name="R875"/>
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="RisAnaResCodRKA1" type="simple:Alphanumeric_Max5">
+        <xs:annotation>
+          <xs:documentation>
+            <doc:description value="Risk Analysis result code"/>
+            <doc:rule name="TR9175"/>
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element minOccurs="0" name="RisAnaTexRKA1" type="simple:Alphanumeric_Max350">
+        <xs:annotation>
+          <xs:documentation>
+            <doc:description value="Risk Analysis text"/>
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element minOccurs="0" name="RisAnaTexRKA1LNG" type="simple:LanguageCodeType">
+        <xs:annotation>
+          <xs:documentation>
+            <doc:description value="Risk Analysis LNG"/>
+            <doc:rule name="TR0099"/>
+            <doc:codeList name="LanguageCodes"/>
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="SEAID529Type">
+    <xs:annotation>
+      <xs:documentation>
+        <doc:description value="SEALS ID"/>
+      </xs:documentation>
+    </xs:annotation>
+    <xs:sequence>
+      <xs:element name="SeaIdSEAID530" type="simple:Alphanumeric_Max20">
+        <xs:annotation>
+          <xs:documentation>
+            <doc:description value="Seals identity"/>
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element minOccurs="0" name="SeaIdSEAID530LNG" type="simple:LanguageCodeType">
+        <xs:annotation>
+          <xs:documentation>
+            <doc:description value="Seals identity LNG"/>
+            <doc:rule name="TR0099"/>
+            <doc:codeList name="LanguageCodes"/>
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="SEAIDIMP319Type">
+    <xs:annotation>
+      <xs:documentation>
+        <doc:description value="SEALS ID"/>
+      </xs:documentation>
+    </xs:annotation>
+    <xs:sequence>
+      <xs:element name="SeaIdeSEAIDIMP320" type="simple:Alphanumeric_Max20">
+        <xs:annotation>
+          <xs:documentation>
+            <doc:description value="Seals identity"/>
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element minOccurs="0" name="SeaIdeSEAIDIMP321LNG" type="simple:LanguageCodeType">
+        <xs:annotation>
+          <xs:documentation>
+            <doc:description value="Seals identity LNG"/>
+            <doc:rule name="TR0099"/>
+            <doc:codeList name="LanguageCodes"/>
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="SERELE202Type">
+    <xs:annotation>
+      <xs:documentation>
+        <doc:description value="SERIES ELEMENTS"/>
+      </xs:documentation>
+    </xs:annotation>
+    <xs:sequence>
+      <xs:element minOccurs="0" name="OthCouSERELE100" type="simple:Alpha_2">
+        <xs:annotation>
+          <xs:documentation>
+            <doc:description value="Other country"/>
+            <doc:codeList name="CountryCodesFullList"/>
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="CouSERELE101" type="simple:Numeric_Max9">
+        <xs:annotation>
+          <xs:documentation>
+            <doc:description value="Counter"/>
+            <doc:rule name="R021"/>
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="SERELESTACHA008Type">
+    <xs:annotation>
+      <xs:documentation>
+        <doc:description value="SERIES ELEMENTS"/>
+      </xs:documentation>
+    </xs:annotation>
+    <xs:sequence>
+      <xs:element minOccurs="0" name="SenCouCodSERELE003" type="simple:Alpha_2">
+        <xs:annotation>
+          <xs:documentation>
+            <doc:description value="Sending country code"/>
+            <doc:codeList name="CountryCodesFullList"/>
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element minOccurs="0" name="OthCouCodSERELESTA001" type="simple:Alpha_2">
+        <xs:annotation>
+          <xs:documentation>
+            <doc:description value="Other country code"/>
+            <doc:codeList name="CountryCodesFullList"/>
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="CouSERELESTACHA7800" type="simple:Numeric_Max9">
+        <xs:annotation>
+          <xs:documentation>
+            <doc:description value="Counter"/>
+            <doc:rule name="R021"/>
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="SPEMENGIIMP291Type">
+    <xs:annotation>
+      <xs:documentation>
+        <doc:description value="SPECIAL MENTIONS"/>
+      </xs:documentation>
+    </xs:annotation>
+    <xs:sequence>
+      <xs:element name="AddInfSPEMENGIIMP292" type="simple:Alphanumeric_Max5">
+        <xs:annotation>
+          <xs:documentation>
+            <doc:description value="Additional information coded"/>
+            <doc:rule name="R080"/>
+            <doc:codeList name="AdditionalInformationIdCommon"/>
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="SPEMENMT2Type">
+    <xs:annotation>
+      <xs:documentation>
+        <doc:description value="SPECIAL MENTIONS"/>
+      </xs:documentation>
+    </xs:annotation>
+    <xs:sequence>
+      <xs:element name="AddInfCodMT23" type="simple:Alphanumeric_Max5">
+        <xs:annotation>
+          <xs:documentation>
+            <doc:description value="Additional information coded"/>
+            <doc:rule name="R080"/>
+            <doc:codeList name="AdditionalInformationIdCommon"/>
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="SUBENTCUSOFFIMP245Type">
+    <xs:annotation>
+      <xs:documentation>
+        <doc:description value="(SUBSEQUENT ENTRY) CUSTOMS OFFICE"/>
+      </xs:documentation>
+    </xs:annotation>
+    <xs:sequence>
+      <xs:element name="RefNumSUBENTCUSOFFIMP247" type="simple:CORefNumType">
+        <xs:annotation>
+          <xs:documentation>
+            <doc:description value="Reference number"/>
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="SUMDECREJ251Type">
+    <xs:annotation>
+      <xs:documentation>
+        <doc:description value="SUMMARY DECLARATION REJECTION"/>
+      </xs:documentation>
+    </xs:annotation>
+    <xs:sequence>
+      <xs:element minOccurs="0" name="DocRefNumSUMDEC252" type="simple:MRNType">
+        <xs:annotation>
+          <xs:documentation>
+            <doc:description value="Document/reference number"/>
+            <doc:rule name="R028"/>
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element minOccurs="0" name="SumDecRejIteNumSUMDECREJ555" type="simple:Numeric_Max5">
+        <xs:annotation>
+          <xs:documentation>
+            <doc:description value="Summary Declaration Rejection Item Number"/>
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="SumDecRejReaCodSUMDEC256" type="simple:Numeric_Max2">
+        <xs:annotation>
+          <xs:documentation>
+            <doc:description value="Summary Declaration rejection reason code"/>
+            <doc:codeList name="SummaryDeclarationRejectionReasonCode"/>
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element minOccurs="0" name="SumDecRejReaSUMDEC255" type="simple:Alphanumeric_Max350">
+        <xs:annotation>
+          <xs:documentation>
+            <doc:description value="Summary Declaration rejection reason"/>
+            <doc:condition name="C305"/>
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element minOccurs="0" name="SumDecRejReaCodSUMDEC257LNG" type="simple:LanguageCodeType">
+        <xs:annotation>
+          <xs:documentation>
+            <doc:description value="Summary Declaration rejection reason LNG"/>
+            <doc:rule name="TR0099"/>
+            <doc:codeList name="LanguageCodes"/>
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="TRADED106Type">
+    <xs:annotation>
+      <xs:documentation>
+        <doc:description value="(DEDICATED) TRADER"/>
+      </xs:documentation>
+    </xs:annotation>
+    <xs:sequence>
+      <xs:element name="Nam36" type="simple:TradNameType">
+        <xs:annotation>
+          <xs:documentation>
+            <doc:description value="Name"/>
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="LanCod37" type="simple:LanguageCodeType">
+        <xs:annotation>
+          <xs:documentation>
+            <doc:description value="Language code"/>
+            <doc:codeList name="LanguageCodes"/>
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element minOccurs="0" name="TIN38" type="simple:TINType">
+        <xs:annotation>
+          <xs:documentation>
+            <doc:description value="TIN"/>
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="TRAREQDIV456Type">
+    <xs:annotation>
+      <xs:documentation>
+        <doc:description value="(REQUESTING DIVERSION) TRADER"/>
+      </xs:documentation>
+    </xs:annotation>
+    <xs:sequence>
+      <xs:element minOccurs="0" name="NamTRAREQDIV457" type="simple:TradNameType">
+        <xs:annotation>
+          <xs:documentation>
+            <doc:description value="Name"/>
+            <doc:condition name="C501"/>
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element minOccurs="0" name="StrAndNumTRAREQDIV458" type="simple:StreetNumType">
+        <xs:annotation>
+          <xs:documentation>
+            <doc:description value="Street and number"/>
+            <doc:condition name="C501"/>
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element minOccurs="0" name="CouTRAREQDIV459" type="simple:CountryCodeType">
+        <xs:annotation>
+          <xs:documentation>
+            <doc:description value="Country"/>
+            <doc:condition name="C501"/>
+            <doc:codeList name="CountryCodesFullList"/>
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element minOccurs="0" name="PosCodTRAREQDIV460" type="simple:PostalCodeType">
+        <xs:annotation>
+          <xs:documentation>
+            <doc:description value="Postal code"/>
+            <doc:condition name="C501"/>
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element minOccurs="0" name="CitTRAREQDIV461" type="simple:CityType">
+        <xs:annotation>
+          <xs:documentation>
+            <doc:description value="City"/>
+            <doc:condition name="C501"/>
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element minOccurs="0" name="TRAREQDIV456LNG" type="simple:LanguageCodeType">
+        <xs:annotation>
+          <xs:documentation>
+            <doc:description value="NAD LNG"/>
+            <doc:rule name="TR0099"/>
+            <doc:codeList name="LanguageCodes"/>
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="TINTRAREQDIV463" type="simple:TINType">
+        <xs:annotation>
+          <xs:documentation>
+            <doc:description value="TIN"/>
+            <doc:rule name="R837"/>
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="UPEUPEType">
+    <xs:annotation>
+      <xs:documentation>
+        <doc:description value="UPL ERROR"/>
+      </xs:documentation>
+    </xs:annotation>
+    <xs:sequence>
+      <xs:element name="ActIdUPE1" type="simple:Alphanumeric_Max20">
+        <xs:annotation>
+          <xs:documentation>
+            <doc:description value="Action identification"/>
+            <doc:rule name="TR9009"/>
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element minOccurs="0" name="AttPatUPE2" type="simple:Alphanumeric_Max140">
+        <xs:annotation>
+          <xs:documentation>
+            <doc:description value="Attribute path"/>
+            <doc:rule name="TR9010"/>
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="CodUPE3" type="simple:Alphanumeric_Max8">
+        <xs:annotation>
+          <xs:documentation>
+            <doc:description value="Code"/>
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element minOccurs="0" name="DescUPE4" type="simple:Alphanumeric_Max210">
+        <xs:annotation>
+          <xs:documentation>
+            <doc:description value="Description"/>
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="UPRUPRType">
+    <xs:annotation>
+      <xs:documentation>
+        <doc:description value="UPL RESPONSE"/>
+      </xs:documentation>
+    </xs:annotation>
+    <xs:sequence>
+      <xs:element name="OrMesIdUPR1" type="simple:Alphanumeric_Max14">
+        <xs:annotation>
+          <xs:documentation>
+            <doc:description value="Original message identification"/>
+            <doc:rule name="TR9006"/>
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="StatUPR2" type="simple:Alpha_Max8">
+        <xs:annotation>
+          <xs:documentation>
+            <doc:description value="Status"/>
+            <doc:rule name="TR9007"/>
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element minOccurs="0" name="DescUPR3" type="simple:Alphanumeric_Max210">
+        <xs:annotation>
+          <xs:documentation>
+            <doc:description value="Description"/>
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="XMLERR805Type">
+    <xs:annotation>
+      <xs:documentation>
+        <doc:description value="XML ERROR"/>
+      </xs:documentation>
+    </xs:annotation>
+    <xs:sequence>
+      <xs:element minOccurs="0" name="ErrLocXMLER803" type="simple:Alphanumeric_Max350">
+        <xs:annotation>
+          <xs:documentation>
+            <doc:description value="Error Location"/>
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="ErrLinNumXMLER800" type="simple:Numeric_Max9">
+        <xs:annotation>
+          <xs:documentation>
+            <doc:description value="Error Line Number"/>
+            <doc:rule name="R021"/>
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="ErrColNumXMLER801" type="simple:Numeric_Max9">
+        <xs:annotation>
+          <xs:documentation>
+            <doc:description value="Error Column Number"/>
+            <doc:rule name="R021"/>
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="ErrReaXMLER802" type="simple:Alphanumeric_Max350">
+        <xs:annotation>
+          <xs:documentation>
+            <doc:description value="Error Reason"/>
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element minOccurs="0" name="OriAttValXMLER804" type="simple:Alphanumeric_Max350">
+        <xs:annotation>
+          <xs:documentation>
+            <doc:description value="Original attribute value"/>
+            <doc:rule name="TR9250"/>
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="ErrCodXMLER806" type="tcl:XmlErrorCodes">
+        <xs:annotation>
+          <xs:documentation>
+            <doc:description value="Error Code"/>
+            <doc:codeList name="XmlErrorCodes"/>
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+    </xs:sequence>
+  </xs:complexType>
+</xs:schema>

--- a/test/resources/schema/doc-v11-2.xsd
+++ b/test/resources/schema/doc-v11-2.xsd
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:doc="http://ics.dgtaxud.ec/doc" targetNamespace="http://ics.dgtaxud.ec/doc" version="11.1" id="doc" elementFormDefault="unqualified" attributeFormDefault="unqualified">
+  <xs:element name="description">
+    <xs:complexType>
+      <xs:attribute use="required" name="value" type="xs:token"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="rule">
+    <xs:complexType>
+      <xs:attribute use="required" name="name" type="xs:token"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="condition">
+    <xs:complexType>
+      <xs:attribute use="required" name="name" type="xs:token"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="codeList">
+    <xs:complexType>
+      <xs:attribute use="required" name="name" type="xs:token"/>
+      <xs:attribute default="technical" name="type" type="xs:token"/>
+    </xs:complexType>
+  </xs:element>
+</xs:schema>

--- a/test/resources/schema/simple_types-v11-2.xsd
+++ b/test/resources/schema/simple_types-v11-2.xsd
@@ -1,0 +1,662 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:simple="http://ics.dgtaxud.ec/simple" targetNamespace="http://ics.dgtaxud.ec/simple" version="11.1" id="simple_types" elementFormDefault="unqualified" attributeFormDefault="unqualified">
+  <xs:simpleType name="AlphaCapital1Type">
+    <xs:restriction base="simple:AlphaCapitalType">
+      <xs:length value="1"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="AlphaCapital2Type">
+    <xs:restriction base="simple:AlphaCapitalType">
+      <xs:length value="2"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="AlphaCapital3Type">
+    <xs:restriction base="simple:AlphaCapitalType">
+      <xs:length value="3"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="AlphaCapital4Type">
+    <xs:restriction base="simple:AlphaCapitalType">
+      <xs:length value="4"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="AlphaCapitalMax3Type">
+    <xs:restriction base="simple:AlphaCapitalType">
+      <xs:maxLength value="3"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="AlphaCapitalType">
+    <xs:restriction base="simple:AlphaType">
+      <xs:pattern value="[A-Z]*"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="AlphaNumType">
+    <xs:annotation>
+      <xs:documentation>Base class for all anN and an..N types</xs:documentation>
+    </xs:annotation>
+    <xs:restriction base="xs:token"/>
+  </xs:simpleType>
+  <xs:simpleType name="AlphaType">
+    <xs:annotation>
+      <xs:documentation>Base class for all aN and a..N
+				types</xs:documentation>
+    </xs:annotation>
+    <xs:restriction base="xs:token"/>
+  </xs:simpleType>
+  <xs:simpleType name="Alpha_1">
+    <xs:restriction base="simple:AlphaType">
+      <xs:length value="1"/>
+      <xs:pattern value="[a-zA-Z]"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="Alpha_2">
+    <xs:restriction base="simple:AlphaType">
+      <xs:length value="2"/>
+      <xs:pattern value="[a-zA-Z]{2}"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="Alpha_3">
+    <xs:restriction base="simple:AlphaType">
+      <xs:length value="3"/>
+      <xs:pattern value="[a-zA-Z]{3}"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="Alpha_4">
+    <xs:restriction base="simple:AlphaType">
+      <xs:length value="4"/>
+      <xs:pattern value="[a-zA-Z]{4}"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="Alpha_Max8">
+    <xs:restriction base="simple:AlphaType">
+      <xs:maxLength value="8"/>
+      <xs:pattern value="[a-zA-Z]{1,8}"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="AlphanumericCapital1Type">
+    <xs:restriction base="simple:AlphanumericCapitalType">
+      <xs:length value="1"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="AlphanumericCapital2Type">
+    <xs:restriction base="simple:AlphanumericCapitalType">
+      <xs:length value="2"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="AlphanumericCapital3Type">
+    <xs:restriction base="simple:AlphanumericCapitalType">
+      <xs:length value="3"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="AlphanumericCapital5Type">
+    <xs:restriction base="simple:AlphanumericCapitalType">
+      <xs:length value="5"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="AlphanumericCapitalMax2Type">
+    <xs:restriction base="simple:AlphanumericCapitalType">
+      <xs:maxLength value="2"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="AlphanumericCapitalMax3Type">
+    <xs:restriction base="simple:AlphanumericCapitalType">
+      <xs:maxLength value="3"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="AlphanumericCapitalMax4Type">
+    <xs:restriction base="simple:AlphanumericCapitalType">
+      <xs:maxLength value="4"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="AlphanumericCapitalMax5Type">
+    <xs:restriction base="simple:AlphanumericCapitalType">
+      <xs:maxLength value="5"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="AlphanumericCapitalMax6Type">
+    <xs:restriction base="simple:AlphanumericCapitalType">
+      <xs:maxLength value="6"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="AlphanumericCapitalMax9Type">
+    <xs:restriction base="simple:AlphanumericCapitalType">
+      <xs:maxLength value="9"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="AlphanumericCapitalType">
+    <xs:restriction base="simple:AlphaNumType">
+      <xs:pattern value="[A-Z0-9]*"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="AlphanumericCapitalTypeOfDeclaration">
+    <xs:restriction base="simple:AlphanumericCapitalMax9Type">
+      <xs:pattern value="[A-Z0-9]*"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="AlphanumericSpecMax35Type">
+    <xs:restriction base="simple:AlphaNumType">
+      <xs:maxLength value="35"/>
+      <xs:pattern value="[a-zA-Z]{2}.{1,33}"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="Alphanumeric_1">
+    <xs:restriction base="simple:AlphaNumType">
+      <xs:length value="1"/>
+      <xs:pattern value=".{1}"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="Alphanumeric_2">
+    <xs:restriction base="simple:AlphaNumType">
+      <xs:length value="2"/>
+      <xs:pattern value=".{2}"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="Alphanumeric_3">
+    <xs:restriction base="simple:AlphaNumType">
+      <xs:length value="3"/>
+      <xs:pattern value=".{3}"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="Alphanumeric_4">
+    <xs:restriction base="simple:AlphaNumType">
+      <xs:length value="4"/>
+      <xs:pattern value=".{4}"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="Alphanumeric_5">
+    <xs:restriction base="simple:AlphaNumType">
+      <xs:length value="5"/>
+      <xs:pattern value=".{5}"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="Alphanumeric_8">
+    <xs:restriction base="simple:AlphaNumType">
+      <xs:length value="8"/>
+      <xs:pattern value=".{8}"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="Alphanumeric_Capital_5">
+    <xs:restriction base="simple:AlphanumericCapitalType">
+      <xs:length value="5"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="Alphanumeric_Max14">
+    <xs:restriction base="simple:AlphaNumType">
+      <xs:maxLength value="14"/>
+      <xs:pattern value=".{1,14}"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="Alphanumeric_Max140">
+    <xs:restriction base="simple:AlphaNumType">
+      <xs:maxLength value="140"/>
+      <xs:pattern value=".{1,140}"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="Alphanumeric_Max15">
+    <xs:restriction base="simple:AlphaNumType">
+      <xs:maxLength value="15"/>
+      <xs:pattern value=".{1,15}"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="Alphanumeric_Max17">
+    <xs:restriction base="simple:AlphaNumType">
+      <xs:maxLength value="17"/>
+      <xs:pattern value=".{1,17}"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="Alphanumeric_Max175">
+    <xs:restriction base="simple:AlphaNumType">
+      <xs:maxLength value="175"/>
+      <xs:pattern value=".{1,175}"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="Alphanumeric_Max2">
+    <xs:restriction base="simple:AlphaNumType">
+      <xs:maxLength value="2"/>
+      <xs:pattern value=".{1,2}"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="Alphanumeric_Max20">
+    <xs:restriction base="simple:AlphaNumType">
+      <xs:maxLength value="20"/>
+      <xs:pattern value=".{1,20}"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="Alphanumeric_Max21">
+    <xs:restriction base="simple:AlphaNumType">
+      <xs:maxLength value="21"/>
+      <xs:pattern value=".{1,21}"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="Alphanumeric_Max210">
+    <xs:restriction base="simple:AlphaNumType">
+      <xs:maxLength value="210"/>
+      <xs:pattern value=".{1,210}"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="Alphanumeric_Max22">
+    <xs:restriction base="simple:AlphaNumType">
+      <xs:maxLength value="22"/>
+      <xs:pattern value=".{1,22}"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="Alphanumeric_Max27">
+    <xs:restriction base="simple:AlphaNumType">
+      <xs:maxLength value="27"/>
+      <xs:pattern value=".{1,27}"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="Alphanumeric_Max280">
+    <xs:restriction base="simple:AlphaNumType">
+      <xs:maxLength value="280"/>
+      <xs:pattern value=".{1,280}"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="Alphanumeric_Max29">
+    <xs:restriction base="simple:AlphaNumType">
+      <xs:maxLength value="29"/>
+      <xs:pattern value=".{1,29}"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="Alphanumeric_Max3">
+    <xs:restriction base="simple:AlphaNumType">
+      <xs:maxLength value="3"/>
+      <xs:pattern value=".{1,3}"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="Alphanumeric_Max35">
+    <xs:restriction base="simple:AlphaNumType">
+      <xs:maxLength value="35"/>
+      <xs:pattern value=".{1,35}"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="Alphanumeric_Max350">
+    <xs:restriction base="simple:AlphaNumType">
+      <xs:maxLength value="350"/>
+      <xs:pattern value=".{1,350}"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="Alphanumeric_Max4">
+    <xs:restriction base="simple:AlphaNumType">
+      <xs:maxLength value="4"/>
+      <xs:pattern value=".{1,4}"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="Alphanumeric_Max42">
+    <xs:restriction base="simple:AlphaNumType">
+      <xs:maxLength value="42"/>
+      <xs:pattern value=".{1,42}"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="Alphanumeric_Max5">
+    <xs:restriction base="simple:AlphaNumType">
+      <xs:maxLength value="5"/>
+      <xs:pattern value=".{1,5}"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="Alphanumeric_Max6">
+    <xs:restriction base="simple:AlphaNumType">
+      <xs:maxLength value="6"/>
+      <xs:pattern value=".{1,6}"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="Alphanumeric_Max70">
+    <xs:restriction base="simple:AlphaNumType">
+      <xs:maxLength value="70"/>
+      <xs:pattern value=".{1,70}"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="Alphanumeric_Max8">
+    <xs:restriction base="simple:AlphaNumType">
+      <xs:maxLength value="8"/>
+      <xs:pattern value=".{1,8}"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="CORefNumType">
+    <xs:annotation>
+      <xs:documentation>Customs Office Reference Number
+				(format:an8)</xs:documentation>
+    </xs:annotation>
+    <xs:restriction base="simple:AlphaNumType">
+      <xs:length value="8"/>
+      <xs:pattern value="[a-zA-Z]{2}[a-zA-Z0-9]{6}"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="CityType">
+    <xs:annotation>
+      <xs:documentation>Trader City (format:
+				an..35)</xs:documentation>
+    </xs:annotation>
+    <xs:restriction base="simple:AlphaNumType">
+      <xs:maxLength value="35"/>
+      <xs:pattern value=".{1,35}"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="CommodityCodeType">
+    <xs:restriction base="simple:AlphaNumType">
+      <xs:pattern value="[0-9]{1,8}"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="CountryCodeType">
+    <xs:annotation>
+      <xs:documentation>Country Code (format:a2)</xs:documentation>
+    </xs:annotation>
+    <xs:restriction base="simple:AlphaType">
+      <xs:length value="2"/>
+      <xs:pattern value="[A-Z]{2}"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="DatePrepType">
+    <xs:annotation>
+      <xs:documentation>Date type (format
+				YYMMDD)</xs:documentation>
+    </xs:annotation>
+    <xs:restriction base="simple:NumType">
+      <xs:length value="6"/>
+      <xs:pattern value="[0-9]{2}(([0][1|3|5|7|8])([0][1-9]|[1-2][0-9]|[3][0-1])|([0][4|6|9])([0][1-9]|[1-2][0-9]|[3][0])|([0][2])([0][1-9]|[1-2][0-9])|([1][0|2])([0][1-9]|[1-2][0-9]|[3][0-1])|([1][1])([0][1-9]|[1-2][0-9]|[3][0]))"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="DateTimeType">
+    <xs:annotation>
+      <xs:documentation>Date and Time with precision of minute
+				(format
+				YYYYMMDDHHMM)</xs:documentation>
+    </xs:annotation>
+    <xs:restriction base="simple:AlphaNumType">
+      <xs:length value="12"/>
+      <xs:pattern value="[1-9][0-9][0-9][0-9](([0][1|3|5|7|8])([0][1-9]|[1-2][0-9]|[3][0-1])|([0][4|6|9])([0][1-9]|[1-2][0-9]|[3][0])|([0][2])([0][1-9]|[1-2][0-9])|([1][0|2])([0][1-9]|[1-2][0-9]|[3][0-1])|([1][1])([0][1-9]|[1-2][0-9]|[3][0]))(([2][0-3]|[0][0-9]|[1][0-9])([0-5][0-9]))"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="DateType">
+    <xs:annotation>
+      <xs:documentation>Date type (format
+				YYYYMMDD)</xs:documentation>
+    </xs:annotation>
+    <xs:restriction base="simple:NumType">
+      <xs:length value="8"/>
+      <xs:pattern value="[1-9][0-9]{3}(([0][1|3|5|7|8])([0][1-9]|[1-2][0-9]|[3][0-1])|([0][4|6|9])([0][1-9]|[1-2][0-9]|[3][0])|([0][2])([0][1-9]|[1-2][0-9])|([1][0|2])([0][1-9]|[1-2][0-9]|[3][0-1])|([1][1])([0][1-9]|[1-2][0-9]|[3][0]))"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="DateTypeExtended">
+    <xs:annotation>
+      <xs:documentation>Date type (format
+				YYYYMMDDHHMNSS)</xs:documentation>
+    </xs:annotation>
+    <xs:restriction base="simple:AlphaNumType">
+      <xs:length value="14"/>
+      <xs:pattern value="[1-9][0-9][0-9]{2}(([0][1|3|5|7|8])([0][1-9]|[1-2][0-9]|[3][0-1])|([0][4|6|9])([0][1-9]|[1-2][0-9]|[3][0])|([0][2])([0][1-9]|[1-2][0-9])|([1][0|2])([0][1-9]|[1-2][0-9]|[3][0-1])|([1][1])([0][1-9]|[1-2][0-9]|[3][0]))([2][0-3]|[0][0-9]|[1][0-9])([0-5][0-9])(0-5)(0-9)(0-5)(0-9)"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="DayInTheMonthType">
+    <xs:annotation>
+      <xs:documentation>Day in the Month (format:
+				DD)</xs:documentation>
+    </xs:annotation>
+    <xs:restriction base="simple:NumType">
+      <xs:length value="2"/>
+      <xs:pattern value="[0][1-9]|[1-2][0-9]|[3][0-1]"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="DecType">
+    <xs:annotation>
+      <xs:documentation>Base class for all n..N,M
+				types</xs:documentation>
+    </xs:annotation>
+    <xs:restriction base="xs:decimal"/>
+  </xs:simpleType>
+  <xs:simpleType name="Decimal_11_3">
+    <xs:restriction base="simple:DecType">
+      <xs:totalDigits value="11"/>
+      <xs:fractionDigits value="3"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="Decimal_15_2">
+    <xs:restriction base="simple:DecType">
+      <xs:totalDigits value="15"/>
+      <xs:fractionDigits value="2"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="Decimal_6_5">
+    <xs:restriction base="simple:DecType">
+      <xs:totalDigits value="6"/>
+      <xs:fractionDigits value="5"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="Decimal_8_6">
+    <xs:restriction base="simple:DecType">
+      <xs:totalDigits value="8"/>
+      <xs:fractionDigits value="6"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="DeclarationRequestNumberType">
+    <xs:annotation>
+      <xs:documentation>Declaration request number (format:
+				an..22)</xs:documentation>
+    </xs:annotation>
+    <xs:restriction base="simple:AlphaNumType">
+      <xs:maxLength value="22"/>
+      <xs:pattern value="[a-zA-Z]{2}.{1,20}"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="GRNType">
+    <xs:annotation>
+      <xs:documentation>GRN (format: an..24), (alias:GuaRefNumGRNREF21)</xs:documentation>
+    </xs:annotation>
+    <xs:restriction base="simple:AlphanumericCapitalType">
+      <xs:pattern value="[0-9]{2}[A-Z]{2}[A-Z0-9]{12}.{1,8}"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="LanguageCodeType">
+    <xs:annotation>
+      <xs:documentation>Language Code (format: a2)</xs:documentation>
+    </xs:annotation>
+    <xs:restriction base="simple:AlphaType">
+      <xs:length value="2"/>
+      <xs:pattern value="[a-zA-Z]{2}"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="MRNType">
+    <xs:annotation>
+      <xs:documentation>MRN (format: an..21), (alias: DocNumHEA5Type)</xs:documentation>
+    </xs:annotation>
+    <xs:restriction base="simple:AlphaNumType">
+      <xs:pattern value="[0-9]{2}[A-Z]{2}[A-Z0-9]{13}[0-9]"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="NumType">
+    <xs:annotation>
+      <xs:documentation>Base class for all nN and n..N
+				types</xs:documentation>
+    </xs:annotation>
+    <xs:restriction base="xs:token"/>
+  </xs:simpleType>
+  <xs:simpleType name="Numeric2">
+    <xs:restriction base="simple:NumType">
+      <xs:length value="2"/>
+      <xs:pattern value="[0-9]{2}"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="Numeric2Max">
+    <xs:restriction base="simple:NumType">
+      <xs:maxLength value="8"/>
+      <xs:pattern value="[0-9]{1,2}"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="Numeric3">
+    <xs:restriction base="simple:NumType">
+      <xs:length value="3"/>
+      <xs:pattern value="[0-9]{3}"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="Numeric4">
+    <xs:restriction base="simple:NumType">
+      <xs:length value="4"/>
+      <xs:pattern value="[0-9]{4}"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="Numeric6Max">
+    <xs:restriction base="simple:NumType">
+      <xs:maxLength value="8"/>
+      <xs:pattern value="[0-9]{1,6}"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="Numeric8Max">
+    <xs:restriction base="simple:NumType">
+      <xs:maxLength value="8"/>
+      <xs:pattern value="[0-9]{1,8}"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="NumericMin4Max8">
+    <xs:restriction base="simple:NumType">
+      <xs:pattern value="[0-9]{4,8}"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="NumericMin4Max8Type">
+    <xs:restriction base="simple:NumType">
+      <xs:pattern value="[0-9]{4,8}"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="Numeric_1">
+    <xs:restriction base="simple:NumType">
+      <xs:length value="1"/>
+      <xs:pattern value="[0-9]"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="Numeric_2">
+    <xs:restriction base="simple:NumType">
+      <xs:length value="2"/>
+      <xs:pattern value="[0-9]{2}"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="Numeric_3">
+    <xs:restriction base="simple:NumType">
+      <xs:length value="3"/>
+      <xs:pattern value="[0-9]{3}"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="Numeric_4">
+    <xs:restriction base="simple:NumType">
+      <xs:length value="4"/>
+      <xs:pattern value="[0-9]{4}"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="Numeric_Max11">
+    <xs:restriction base="simple:NumType">
+      <xs:maxLength value="11"/>
+      <xs:pattern value="[0-9]{1,11}"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="Numeric_Max2">
+    <xs:restriction base="simple:NumType">
+      <xs:maxLength value="2"/>
+      <xs:pattern value="[0-9]{1,2}"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="Numeric_Max3">
+    <xs:restriction base="simple:NumType">
+      <xs:maxLength value="3"/>
+      <xs:pattern value="[0-9]{1,3}"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="Numeric_Max4">
+    <xs:restriction base="simple:NumType">
+      <xs:maxLength value="4"/>
+      <xs:pattern value="[0-9]{1,4}"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="Numeric_Max5">
+    <xs:restriction base="simple:NumType">
+      <xs:maxLength value="5"/>
+      <xs:pattern value="[0-9]{1,5}"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="Numeric_Max6">
+    <xs:restriction base="simple:NumType">
+      <xs:maxLength value="6"/>
+      <xs:pattern value="[0-9]{1,6}"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="Numeric_Max7">
+    <xs:restriction base="simple:NumType">
+      <xs:maxLength value="7"/>
+      <xs:pattern value="[0-9]{1,7}"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="Numeric_Max9">
+    <xs:restriction base="simple:NumType">
+      <xs:maxLength value="9"/>
+      <xs:pattern value="[0-9]{1,9}"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="PostalCodeType">
+    <xs:annotation>
+      <xs:documentation>Trader Postal Code (format:
+				n..9)</xs:documentation>
+    </xs:annotation>
+    <xs:restriction base="simple:AlphaNumType">
+      <xs:maxLength value="9"/>
+      <xs:pattern value=".{1,9}"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="StreetNumType">
+    <xs:annotation>
+      <xs:documentation>Trader Street and Number (format:
+				an..35)</xs:documentation>
+    </xs:annotation>
+    <xs:restriction base="simple:AlphaNumType">
+      <xs:maxLength value="35"/>
+      <xs:pattern value=".{1,35}"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="StringLatin1">
+    <xs:restriction base="xs:string">
+      <xs:pattern value="\p{IsBasicLatin}+"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="TINType">
+    <xs:annotation>
+      <xs:documentation>Trader Identification Number (format:
+				an..17)</xs:documentation>
+    </xs:annotation>
+    <xs:restriction base="simple:StringLatin1">
+      <xs:minLength value="3"/>
+      <xs:maxLength value="17"/>
+      <xs:pattern value="[A-Z]{2}[^\n\r]*"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="TaricCodeType">
+    <xs:annotation>
+      <xs:documentation>Taric Code (format:
+				an..6)</xs:documentation>
+    </xs:annotation>
+    <xs:restriction base="simple:AlphaNumType">
+      <xs:pattern value="[0-9]{1,6}"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="TimeType">
+    <xs:annotation>
+      <xs:documentation>Time with precision of minute (format
+				HHMM)</xs:documentation>
+    </xs:annotation>
+    <xs:restriction base="simple:NumType">
+      <xs:length value="4"/>
+      <xs:pattern value="([2][0-3]|[0][0-9]|[1][0-9])([0-5][0-9])"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="TradNameType">
+    <xs:annotation>
+      <xs:documentation>Trader Name (format:
+				an..35)</xs:documentation>
+    </xs:annotation>
+    <xs:restriction base="simple:AlphaNumType">
+      <xs:maxLength value="35"/>
+      <xs:pattern value=".{1,35}"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="emailAddressType">
+    <xs:restriction base="simple:StringLatin1">
+      <xs:maxLength value="70"/>
+      <xs:pattern value="[^@]+@[^\.]+\..+"/>
+    </xs:restriction>
+  </xs:simpleType>
+</xs:schema>

--- a/test/resources/schema/tcl-v11-2.xsd
+++ b/test/resources/schema/tcl-v11-2.xsd
@@ -1,0 +1,769 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:tcl="http://ics.dgtaxud.ec/tcl" targetNamespace="http://ics.dgtaxud.ec/tcl" version="11.1" id="tcl" elementFormDefault="unqualified" attributeFormDefault="unqualified">
+  <xs:simpleType name="BusinessFunctionalityCode">
+    <xs:annotation>
+      <xs:documentation>[Format: a1]</xs:documentation>
+    </xs:annotation>
+    <xs:restriction base="xs:token">
+      <xs:enumeration value="H">
+        <xs:annotation>
+          <xs:documentation>Reference Data</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="U">
+        <xs:annotation>
+          <xs:documentation>Entry Processing</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="V">
+        <xs:annotation>
+          <xs:documentation>Lodgement</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="W">
+        <xs:annotation>
+          <xs:documentation>ALL FUNCTIONALITY</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="CountryCodesCustomsOfficeLists">
+    <xs:annotation>
+      <xs:documentation>All the countries included in code list 9 excluding AX, GF, GP, LI, MC, MQ, RE, SJ and YT. The same codelist values are used for all Domains (ECS/NCTS/ICS) in order to support the COL. Values are shown for illustration only. [Format: a2]</xs:documentation>
+    </xs:annotation>
+    <xs:restriction base="xs:token">
+      <xs:enumeration value="AD">
+        <xs:annotation>
+          <xs:documentation>Andorra</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="AT">
+        <xs:annotation>
+          <xs:documentation>Austria</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="BE">
+        <xs:annotation>
+          <xs:documentation>Belgium</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="BG">
+        <xs:annotation>
+          <xs:documentation>Bulgaria</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="CH">
+        <xs:annotation>
+          <xs:documentation>Switzerland</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="CY">
+        <xs:annotation>
+          <xs:documentation>Cyprus</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="CZ">
+        <xs:annotation>
+          <xs:documentation>Czech Republic</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="DE">
+        <xs:annotation>
+          <xs:documentation>Germany</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="DK">
+        <xs:annotation>
+          <xs:documentation>Denmark</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="EE">
+        <xs:annotation>
+          <xs:documentation>Estonia</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="ES">
+        <xs:annotation>
+          <xs:documentation>Spain</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="FI">
+        <xs:annotation>
+          <xs:documentation>Finland</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="FR">
+        <xs:annotation>
+          <xs:documentation>France</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="GB">
+        <xs:annotation>
+          <xs:documentation>United Kingdom</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="GR">
+        <xs:annotation>
+          <xs:documentation>Greece</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="HR">
+        <xs:annotation>
+          <xs:documentation>Croatia</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="HU">
+        <xs:annotation>
+          <xs:documentation>Hungary</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="IE">
+        <xs:annotation>
+          <xs:documentation>Ireland</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="IS">
+        <xs:annotation>
+          <xs:documentation>Iceland</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="IT">
+        <xs:annotation>
+          <xs:documentation>Italy</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="LT">
+        <xs:annotation>
+          <xs:documentation>Lithuania</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="LU">
+        <xs:annotation>
+          <xs:documentation>Luxembourg</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="LV">
+        <xs:annotation>
+          <xs:documentation>Latvia</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="MT">
+        <xs:annotation>
+          <xs:documentation>Malta</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="NL">
+        <xs:annotation>
+          <xs:documentation>Netherlands</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="NO">
+        <xs:annotation>
+          <xs:documentation>Norway</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="PL">
+        <xs:annotation>
+          <xs:documentation>Poland</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="PT">
+        <xs:annotation>
+          <xs:documentation>Portugal</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="RO">
+        <xs:annotation>
+          <xs:documentation>Romania</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="SE">
+        <xs:annotation>
+          <xs:documentation>Sweden</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="SI">
+        <xs:annotation>
+          <xs:documentation>Slovenia</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="SK">
+        <xs:annotation>
+          <xs:documentation>Slovakia</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="SM">
+        <xs:annotation>
+          <xs:documentation>San Marino</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="TR">
+        <xs:annotation>
+          <xs:documentation>Turkey</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="DayInTheWeek">
+    <xs:annotation>
+      <xs:documentation>[Format: n1]</xs:documentation>
+    </xs:annotation>
+    <xs:restriction base="xs:token">
+      <xs:enumeration value="1">
+        <xs:annotation>
+          <xs:documentation>Monday</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="2">
+        <xs:annotation>
+          <xs:documentation>Tuesday</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="3">
+        <xs:annotation>
+          <xs:documentation>Wednesday</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="4">
+        <xs:annotation>
+          <xs:documentation>Thursday</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="5">
+        <xs:annotation>
+          <xs:documentation>Friday</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="6">
+        <xs:annotation>
+          <xs:documentation>Saturday</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="7">
+        <xs:annotation>
+          <xs:documentation>Sunday</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="EoriAeoErrorCode">
+    <xs:annotation>
+      <xs:documentation>It is an alphanumerical up to 50 characters string (i.e. an..50) that is used to define in an acknowledgement notification message the error code(s). [Format: an..50]</xs:documentation>
+    </xs:annotation>
+    <xs:restriction base="xs:token">
+      <xs:enumeration value="GEN-CORR">
+        <xs:annotation>
+          <xs:documentation>Non XML message received</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="GEN-INVALID-BYTE-SEQUENCE">
+        <xs:annotation>
+          <xs:documentation>Invalid byte sequence: a byte sequence does not represent a valid character in the character encoding scheme (UTF-8).</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="GEN-WRONG-ENVID">
+        <xs:annotation>
+          <xs:documentation>Envelope Id and/or Originator Reference are missing</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="FunctionalErrorCodes">
+    <xs:annotation>
+      <xs:documentation>- Subset of the UN/EDIFACT generic error table. - For remarks on the codes : see DDNTA Sec. VII. [Format: n2]</xs:documentation>
+    </xs:annotation>
+    <xs:restriction base="xs:token">
+      <xs:enumeration value="12">
+        <xs:annotation>
+          <xs:documentation>Incorrect (code) value</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="13">
+        <xs:annotation>
+          <xs:documentation>Missing</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="14">
+        <xs:annotation>
+          <xs:documentation>Value not supported in this position (code value constraint)</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="15">
+        <xs:annotation>
+          <xs:documentation>Not supported in this position</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="19">
+        <xs:annotation>
+          <xs:documentation>Invalid decimal notation</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="26">
+        <xs:annotation>
+          <xs:documentation>Duplicate detected</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="35">
+        <xs:annotation>
+          <xs:documentation>Too many repetitions</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="37">
+        <xs:annotation>
+          <xs:documentation>Invalid type characters</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="38">
+        <xs:annotation>
+          <xs:documentation>Missing digit in front of decimal sign</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="39">
+        <xs:annotation>
+          <xs:documentation>Element too long (length constraint)</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="40">
+        <xs:annotation>
+          <xs:documentation>Element too short (length constraint)</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="90">
+        <xs:annotation>
+          <xs:documentation>Unknown MRN</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="91">
+        <xs:annotation>
+          <xs:documentation>Duplicate MRN</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="92">
+        <xs:annotation>
+          <xs:documentation>Message out of sequence</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="93">
+        <xs:annotation>
+          <xs:documentation>Invalid MRN</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="XmlErrorCodes">
+    <xs:annotation>
+      <xs:documentation>Defines the codes to be used for reporting errors on XML messages. [Format: n2]</xs:documentation>
+    </xs:annotation>
+    <xs:restriction base="xs:token">
+      <xs:enumeration value="12">
+        <xs:annotation>
+          <xs:documentation>Incorrect enumeration</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="13">
+        <xs:annotation>
+          <xs:documentation>Missing</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="15">
+        <xs:annotation>
+          <xs:documentation>Not supported in this position</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="18">
+        <xs:annotation>
+          <xs:documentation>Unspecified Error / Other</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="19">
+        <xs:annotation>
+          <xs:documentation>Invalid decimal notation</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="35">
+        <xs:annotation>
+          <xs:documentation>Too many repetitions</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="39">
+        <xs:annotation>
+          <xs:documentation>Element too long (length constraint)</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="40">
+        <xs:annotation>
+          <xs:documentation>Element too short (length constraint)</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="50">
+        <xs:annotation>
+          <xs:documentation>Invalid Value for the specific type</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="51">
+        <xs:annotation>
+          <xs:documentation>Invalid value according to the pattern</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="52">
+        <xs:annotation>
+          <xs:documentation>Invalid XML format</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="53">
+        <xs:annotation>
+          <xs:documentation>Invalid character(s)</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="54">
+        <xs:annotation>
+          <xs:documentation>Value is lower than the allowed lowest limit (Minimum Inclusive)</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="55">
+        <xs:annotation>
+          <xs:documentation>Value is greater than the allowed upper limit (Maximum Inclusive)</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="56">
+        <xs:annotation>
+          <xs:documentation>Value is lower than or equal to the allowed lowest limit (Minimum Exlcusive)</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="57">
+        <xs:annotation>
+          <xs:documentation>Value is greater than or equal to the allowed upper limit (Maximum Exclusive)</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="PrefixSuffixLevel">
+    <xs:annotation>
+      <xs:documentation>Used for CUSTOMS OFFICE LSD. [Format: an1]</xs:documentation>
+    </xs:annotation>
+    <xs:restriction base="xs:token">
+      <xs:enumeration value="A">
+        <xs:annotation>
+          <xs:documentation>Simple office (see box A in Customs Office List)</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="E">
+        <xs:annotation>
+          <xs:documentation>Higher authority (see box E in Customs Office List)</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="SystemUnavailabilityType">
+    <xs:annotation>
+      <xs:documentation>Used for the attribute SYSTEM UNAVAILABILITY.System Unavailability Type. [Format: a1]</xs:documentation>
+    </xs:annotation>
+    <xs:restriction base="xs:token">
+      <xs:enumeration value="N">
+        <xs:annotation>
+          <xs:documentation>Business service not implemented</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="S">
+        <xs:annotation>
+          <xs:documentation>Scheduled Unavailability</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="U">
+        <xs:annotation>
+          <xs:documentation>Unscheduled Unavailability</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="Flag">
+    <xs:annotation>
+      <xs:documentation>Used for attributes that can have a positive or a negative value. [Format: n1]</xs:documentation>
+    </xs:annotation>
+    <xs:restriction base="xs:token">
+      <xs:enumeration value="0">
+        <xs:annotation>
+          <xs:documentation>NO</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="1">
+        <xs:annotation>
+          <xs:documentation>YES</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="MonthOfYear">
+    <xs:annotation>
+      <xs:documentation>[Format: an2]</xs:documentation>
+    </xs:annotation>
+    <xs:restriction base="xs:token">
+      <xs:enumeration value="01">
+        <xs:annotation>
+          <xs:documentation>January</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="02">
+        <xs:annotation>
+          <xs:documentation>February</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="03">
+        <xs:annotation>
+          <xs:documentation>March</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="04">
+        <xs:annotation>
+          <xs:documentation>April</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="05">
+        <xs:annotation>
+          <xs:documentation>May</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="06">
+        <xs:annotation>
+          <xs:documentation>June</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="07">
+        <xs:annotation>
+          <xs:documentation>July</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="08">
+        <xs:annotation>
+          <xs:documentation>August</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="09">
+        <xs:annotation>
+          <xs:documentation>September</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="10">
+        <xs:annotation>
+          <xs:documentation>October</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="11">
+        <xs:annotation>
+          <xs:documentation>November</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="12">
+        <xs:annotation>
+          <xs:documentation>December</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="MessageTypes">
+    <xs:annotation>
+      <xs:documentation>Used for attribute MESSAGE ERRORS.Association assigned code and MESSAGE.Message Type. The usage of each code in one of the UNSM templates is defined in the Remarks column. CC should in all cases be instantiated to the value of the particular domain in which the message is created. [Format: an..6] [Format: an..6]</xs:documentation>
+    </xs:annotation>
+    <xs:restriction base="xs:token">
+      <xs:enumeration value="CC304A">
+        <xs:annotation>
+          <xs:documentation>Entry Summary Declaration Amendment Accepted</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="CC305A">
+        <xs:annotation>
+          <xs:documentation>Entry Summary Declaration Amendment Rejection</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="CC313A">
+        <xs:annotation>
+          <xs:documentation>Entry Summary Declaration Amendment</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="CC315A">
+        <xs:annotation>
+          <xs:documentation>Entry Summary Declaration</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="CC316A">
+        <xs:annotation>
+          <xs:documentation>Entry Summary Declaration Rejected</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="CC323A">
+        <xs:annotation>
+          <xs:documentation>Diversion Request Import</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="CC324A">
+        <xs:annotation>
+          <xs:documentation>Diversion Request Rejected</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="CC325A">
+        <xs:annotation>
+          <xs:documentation>Diversion Request Acknowledgement</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="CC328A">
+        <xs:annotation>
+          <xs:documentation>Entry Summary Request Acknowledgement</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="CC351A">
+        <xs:annotation>
+          <xs:documentation>Advanced Intervention Notification</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="CD030C">
+        <xs:annotation>
+          <xs:documentation>Notification of customs offices modification to common domain</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="CD031C">
+        <xs:annotation>
+          <xs:documentation>Notification of customs offices modification to national domain</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="CD032C">
+        <xs:annotation>
+          <xs:documentation>Notification of common reference data modification to ND</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="CD070B">
+        <xs:annotation>
+          <xs:documentation>Notification of System Unavailability to CD</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="CD071B">
+        <xs:annotation>
+          <xs:documentation>Notification of System Unavailability to ND</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="CD301A">
+        <xs:annotation>
+          <xs:documentation>ENS</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="CD302A">
+        <xs:annotation>
+          <xs:documentation>Declaration Request Import</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="CD303A">
+        <xs:annotation>
+          <xs:documentation>Entry Summary Declaration Response</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="CD319A">
+        <xs:annotation>
+          <xs:documentation>Transmission to subsequent Office of Entry</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="CD411C">
+        <xs:annotation>
+          <xs:documentation>Sending of statistics data</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="CD412C">
+        <xs:annotation>
+          <xs:documentation>Statistics generated sent to national domain</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="CD906B">
+        <xs:annotation>
+          <xs:documentation>Functional NACK</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="CD912B">
+        <xs:annotation>
+          <xs:documentation>Availability Matrix</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="CD913B">
+        <xs:annotation>
+          <xs:documentation>Upload parsing response</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="CD914B">
+        <xs:annotation>
+          <xs:documentation>COL request</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="CD916B">
+        <xs:annotation>
+          <xs:documentation>Common RD Request</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="CD917B">
+        <xs:annotation>
+          <xs:documentation>XML NACK</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="CD931C">
+        <xs:annotation>
+          <xs:documentation>COL DATA</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="CD932C">
+        <xs:annotation>
+          <xs:documentation>Common RD Data</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="CD971B">
+        <xs:annotation>
+          <xs:documentation>Full Unavailability Schedule</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="ModificationType">
+    <xs:annotation>
+      <xs:documentation>Used for (multiple) attribute Operation. [Format: a1]</xs:documentation>
+    </xs:annotation>
+    <xs:restriction base="xs:token">
+      <xs:enumeration value="C">
+        <xs:annotation>
+          <xs:documentation>Create</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="D">
+        <xs:annotation>
+          <xs:documentation>Delete</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="U">
+        <xs:annotation>
+          <xs:documentation>Update</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="CustomSystem">
+    <xs:annotation>
+      <xs:documentation>Custom System applicable domain [Format: n..2]</xs:documentation>
+    </xs:annotation>
+    <xs:restriction base="xs:token">
+      <xs:enumeration value="1">
+        <xs:annotation>
+          <xs:documentation>NCTS</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="2">
+        <xs:annotation>
+          <xs:documentation>ECS</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="3">
+        <xs:annotation>
+          <xs:documentation>ICS</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="4">
+        <xs:annotation>
+          <xs:documentation>EOS</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+    </xs:restriction>
+  </xs:simpleType>
+</xs:schema>

--- a/test/serialisation/xml/GoodsItemFormatsSpec.scala
+++ b/test/serialisation/xml/GoodsItemFormatsSpec.scala
@@ -43,6 +43,14 @@ class GoodsItemFormatsSpec extends SpecBase
     }
   }
 
+  "The special mention format" - {
+    "should work symmetrically" in {
+      forAll(arbitrary[SpecialMention]) { sm =>
+        sm.toXml.parseXml[SpecialMention] must be(sm)
+      }
+    }
+  }
+
   "The DocumentType Format" - {
     "should work symmetrically" in {
       forAll(arbitrary[DocumentType]) { c =>
@@ -109,9 +117,33 @@ class GoodsItemFormatsSpec extends SpecBase
 
   "The goods item format" - {
     "should work symmetrically" - {
-      "for any good item" in {
+      "for any goods item" in {
         forAll(arbitrary[GoodsItem]) { item =>
           item.toXml.parseXml[GoodsItem] must be(item)
+        }
+      }
+
+      "when goods item is identified by" - {
+        "commodity code" in {
+          val gen = for {
+            item <- arbitrary[GoodsItem]
+            id <- arbitrary[GoodsItemIdentity.ByCommodityCode]
+          } yield item.copy(itemIdentity = id)
+
+          forAll(gen) { item =>
+            item.toXml.parseXml[GoodsItem] must be(item)
+          }
+        }
+
+        "description" in {
+          val gen = for {
+            item <- arbitrary[GoodsItem]
+            id <- arbitrary[GoodsItemIdentity.WithDescription]
+          } yield item.copy(itemIdentity = id)
+
+          forAll(gen) { item =>
+            item.toXml.parseXml[GoodsItem] must be(item)
+          }
         }
       }
 

--- a/test/serialisation/xml/MetadataFormatsSpec.scala
+++ b/test/serialisation/xml/MetadataFormatsSpec.scala
@@ -71,14 +71,7 @@ class MetadataFormatsSpec
 
   "The metadata format" - {
     "should serialise symmetrically" in {
-      val metadataGen = for {
-        messageId <- stringsWithExactLength(20)
-        messageSender <- arbitrary[MessageSender]
-        messageType <- arbitrary[MessageType]
-        dt <- minutePrecisionInstants
-      } yield Metadata(messageId, messageSender, messageType, dt)
-
-      forAll(metadataGen) { m =>
+      forAll(arbitrary[Metadata]) { m =>
         m.toXml.parseXml[Metadata] must be(m)
       }
     }

--- a/test/serialisation/xml/SubmissionFormatsSpec.scala
+++ b/test/serialisation/xml/SubmissionFormatsSpec.scala
@@ -52,5 +52,12 @@ class SubmissionFormatsSpec
         }
       }
     }
+
+    "should produce a payload which can be validated against the CC315A schema" in {
+      forAll(arbitrary[Submission]) { sub =>
+        val payload = sub.toXml.toString
+        XmlValidator.SubmissionValidator.validate(payload)
+      }
+    }
   }
 }

--- a/test/serialisation/xml/XmlValidator.scala
+++ b/test/serialisation/xml/XmlValidator.scala
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2022 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package serialisation.xml
+
+import java.io.StringReader
+import javax.xml.XMLConstants
+import javax.xml.transform.{Source => XMLSource}
+import javax.xml.transform.sax.SAXSource
+import javax.xml.validation.{Validator, SchemaFactory}
+import org.xml.sax.InputSource
+import scala.io.Source
+
+/**
+ * Validate XML against a list of XML schemata provided as resource filenames relative to /schema
+ */
+class XmlValidator(schemata: Seq[String]) {
+  private def src(data: String): XMLSource = new SAXSource(new InputSource(new StringReader(data)))
+
+  private lazy val validator: Validator = {
+    val sources: Array[XMLSource] = schemata.map { s =>
+      src(Source.fromResource(s"schema/$s").mkString)
+    }.toArray
+
+    SchemaFactory
+      .newInstance(XMLConstants.W3C_XML_SCHEMA_NS_URI)
+      .newSchema(sources)
+      .newValidator()
+  }
+
+  def validate(doc: String): Unit = validator.validate(src(doc))
+}
+
+object XmlValidator {
+  /**
+   * Validate documents against CC315A schemata
+   */
+  object SubmissionValidator extends XmlValidator(
+    Seq(
+      "doc-v11-2.xsd",
+      "tcl-v11-2.xsd",
+      "simple_types-v11-2.xsd",
+      "complex_types_ics-v11-2.xsd",
+      "CC315A-v11-2.xsd"
+    )
+  )
+}


### PR DESCRIPTION
Add the schema test:

- Add the relevant schemata to test resources
- Add a util which will validate against the schemata using java stdlib
  xml APIs
- Add test to serialise payloads to XML and check it against schema

Fix issues highlighted by test:
  - Submission was actually missing the whole Metadata section
  - Fix serialisation order of fields in Metadata
  - Fix metadata date of declaration format from YYYYMMDD to DDMMYY
  - Adjust the year of our arbitraryRecentInstant generator to only give
    us years from this century, given we have to deal with two-digit
    years
  - Many of our generators used incorrect length strings or simply
    arbitrary strings which often resulted in long strings of chinese
    characters. To address this, move string generator methods out into
    StringGenerators and extend that from ModelGenerators
  - SpecialMention format was incorrect, and also missing a test
  - Some other minor formats were slightly incorrect, e.g. seals,
    commodity code
  - The TIN1 (EORI) is required for the lodging person, so change the
    generator for Submission to always give lodging person by EORI

Add some edge case testing in GoodsItemFormatsSpec around commodity code
vs description in the goods item format