### PR TITLE
Remove unused and potentially dangerous implicits

### DIFF
--- a/app/config/Service.scala
+++ b/app/config/Service.scala
@@ -18,8 +18,6 @@ package config
 
 import play.api.{ConfigLoader, Configuration}
 
-import scala.language.implicitConversions
-
 final case class Service(host: String, port: String, protocol: String) {
 
   def baseUrl: String =
@@ -40,7 +38,4 @@ object Service {
 
     Service(host, port, protocol)
   }
-
-  implicit def convertToString(service: Service): String =
-    service.baseUrl
 }

--- a/app/pages/Page.scala
+++ b/app/pages/Page.scala
@@ -20,8 +20,6 @@ import controllers.routes
 import models.{CheckMode, LocalReferenceNumber, Mode, NormalMode, UserAnswers}
 import play.api.mvc.Call
 
-import scala.language.implicitConversions
-
 trait Page {
 
   def navigate(mode: Mode, answers: UserAnswers): Call =
@@ -68,10 +66,4 @@ trait Page {
 
   def changeLink(waypoints: Waypoints, lrn: LocalReferenceNumber, sourcePage: AddItemPage): Call =
     route(waypoints.setNextWaypoint(sourcePage.waypoint(CheckMode)), lrn)
-}
-
-object Page {
-
-  implicit def toString(page: Page): String =
-    page.toString
 }


### PR DESCRIPTION
An implicit conversion from Page to String was included on the Page
companion object. This is dangerous as such implicit conversions can
cause misleading behaviour. Further, this implicit was never actually
used anywhere.

Having spotted that one I also found one in Service doing a very similar
thing.

Remove them.