### PR TITLE
SSUT-520: Do not model PaymentMethod in XML header

### DIFF
--- a/app/models/completion/downstream/TransportDetails.scala
+++ b/app/models/completion/downstream/TransportDetails.scala
@@ -16,7 +16,7 @@
 
 package models.completion.downstream
 
-import models.{Country, PaymentMethod, TransportMode}
+import models.{Country, TransportMode}
 
 /**
  * Summary of the transport details, to be flattened into the XML header information
@@ -24,6 +24,5 @@ import models.{Country, PaymentMethod, TransportMode}
 case class TransportDetails(
   mode: TransportMode,
   identity: String,
-  nationality: Option[Country],
-  paymentMethod: Option[PaymentMethod]
+  nationality: Option[Country]
 )

--- a/app/serialisation/xml/HeaderFormats.scala
+++ b/app/serialisation/xml/HeaderFormats.scala
@@ -38,10 +38,6 @@ trait HeaderFormats extends TransportFormats with TimeFormats {
         <NatOfMeaOfTraCroHEA87>{n.toXmlString}</NatOfMeaOfTraCroHEA87>
       }.toSeq
 
-      val transportPaymentMethod: NodeSeq = header.transportDetails.paymentMethod.map { pm =>
-        <TraChaMetOfPayHEA1>{pm.toXmlString}</TraChaMetOfPayHEA1>
-      }.toSeq
-
       <HEAHEA>
         <RefNumHEA4>{header.lrn.toXmlString}</RefNumHEA4>
         <TraModAtBorHEA76>{header.transportDetails.mode.toXmlString}</TraModAtBorHEA76>
@@ -51,7 +47,6 @@ trait HeaderFormats extends TransportFormats with TimeFormats {
         <TotNumOfPacHEA306>{header.packageCount}</TotNumOfPacHEA306>
         {grossMass}
         <DecPlaHEA394>{header.declarationPlace}</DecPlaHEA394>
-        {transportPaymentMethod}
         <ConRefNumHEA>{header.conveyanceReferenceNumber}</ConRefNumHEA>
         <DecDatTimHEA114>{header.datetime.toXmlString}</DecDatTimHEA114>
       </HEAHEA>

--- a/app/serialisation/xml/TransportFormats.scala
+++ b/app/serialisation/xml/TransportFormats.scala
@@ -83,11 +83,7 @@ trait TransportFormats extends CommonFormats {
         <NatOfMeaOfTraCroHEA87>{n.toXmlString}</NatOfMeaOfTraCroHEA87>
       }.toSeq
 
-      val paymentMethod: NodeSeq = details.paymentMethod.map { pm =>
-        <TraChaMetOfPayHEA1>{pm.toXmlString}</TraChaMetOfPayHEA1>
-      }.toSeq
-
-      requiredFields ++ nationality ++ paymentMethod
+      requiredFields ++ nationality
     }
 
     override def decode(data: NodeSeq): TransportDetails = {
@@ -96,11 +92,8 @@ trait TransportFormats extends CommonFormats {
       val nationality = (data \\ "NatOfMeaOfTraCroHEA87").headOption map {
         _.text.parseXmlString[Country]
       }
-      val paymentMethod = (data \\ "TraChaMetOfPayHEA1").headOption map {
-        _.text.parseXmlString[PaymentMethod]
-      }
 
-      TransportDetails(mode, identifier, nationality, paymentMethod)
+      TransportDetails(mode, identifier, nationality)
     }
   }
 

--- a/test-utils/generators/ModelGenerators.scala
+++ b/test-utils/generators/ModelGenerators.scala
@@ -314,8 +314,7 @@ trait ModelGenerators extends StringGenerators {
       mode <- arbitrary[TransportMode]
       identifier <- stringsWithMaxLength(27)
       nationality <- Gen.option(arbitrary[Country])
-      paymentMethod <- Gen.option(arbitrary[PaymentMethod])
-    } yield TransportDetails(mode, identifier, nationality, paymentMethod)
+    } yield TransportDetails(mode, identifier, nationality)
   }
 
   implicit lazy val arbitraryPayloadHeader: Arbitrary[Header] = Arbitrary {

--- a/test/serialisation/xml/TransportFormatsSpec.scala
+++ b/test/serialisation/xml/TransportFormatsSpec.scala
@@ -35,8 +35,7 @@ class TransportFormatsSpec
       mode <- arbitrary[TransportMode]
       identifier <- Gen.alphaNumStr
       nationality <- Gen.option(arbitrary[Country])
-      paymentMethod <- Gen.option(arbitrary[PaymentMethod])
-    } yield TransportDetails(mode, identifier, nationality, paymentMethod)
+    } yield TransportDetails(mode, identifier, nationality)
   }
 
   "The transport mode format" - {
@@ -63,25 +62,6 @@ class TransportFormatsSpec
         }
       }
 
-      "when carrier payment method" - {
-        "is specified" in {
-          val gen = for {
-            details <- transportDetailsGen
-            pm <- arbitrary[PaymentMethod]
-          } yield details.copy(paymentMethod = Some(pm))
-
-          forAll(gen) { details =>
-            details.toXml.parseXml[TransportDetails] must be(details)
-          }
-        }
-        "is missing" in {
-          val gen = transportDetailsGen map { _.copy(paymentMethod = None) }
-
-          forAll(gen) { details =>
-            details.toXml.parseXml[TransportDetails] must be(details)
-          }
-        }
-      }
       "when transport nationality" - {
         "is specified" in {
           val gen = for {


### PR DESCRIPTION
TransportDetails, a submodel of Header, included an optional
paymentMethod, but we do not collect this in the journey, so we should
exclude it altogether (our payment methods are always provided per good
item instead)