### PR TITLE
SSUT-521: Party.ByEori should use GbEori

### DIFF
--- a/app/extractors/PartiesExtractor.scala
+++ b/app/extractors/PartiesExtractor.scala
@@ -54,7 +54,7 @@ class PartiesExtractor(
 
   private def tradersToParties(traders: List[Trader]): Map[Int, Party] = {
     traders.map {
-      case TraderWithEori(key, eori) => key -> Party.ByEori(eori)
+      case TraderWithEori(key, eori) => key -> Party.ByEori(GbEori(eori))
       case TraderWithoutEori(key, name, addr) => key -> Party.ByAddress(name, addr)
     }.toMap
   }

--- a/app/models/GbEori.scala
+++ b/app/models/GbEori.scala
@@ -27,6 +27,6 @@ import play.api.libs.json._
 case class GbEori(value: String) extends AnyVal
 
 object GbEori {
-  implicit val reads: Reads[GbEori] = Reads.StringReads.map { new GbEori(_) }
+  implicit val reads: Reads[GbEori] = Reads.StringReads.map { GbEori(_) }
   implicit val writes: Writes[GbEori] = Writes.StringWrites.contramap { _.value }
 }

--- a/app/models/completion/Party.scala
+++ b/app/models/completion/Party.scala
@@ -16,7 +16,7 @@
 
 package models.completion
 
-import models.Address
+import models.{Address, GbEori}
 
 /**
  * This identifies any party reported within the XML payload, by EORI or name + address
@@ -27,6 +27,6 @@ import models.Address
 sealed trait Party
 
 object Party {
-  case class ByEori(eori: String) extends Party
+  case class ByEori(eori: GbEori) extends Party
   case class ByAddress(name: String, address: Address) extends Party
 }

--- a/app/serialisation/xml/CommonFormats.scala
+++ b/app/serialisation/xml/CommonFormats.scala
@@ -16,12 +16,23 @@
 
 package serialisation.xml
 
-import models.{Country, LocalReferenceNumber}
+import models.{Country, GbEori, LocalReferenceNumber}
 
 /**
  * XML formats for miscellaneous common or shared data types, e.g. enums, reference numbers, etc.
  */
 trait CommonFormats {
+  implicit val gbEoriFmt: StringFormat[GbEori] = new StringFormat[GbEori] {
+    override def encode(eori: GbEori): String = s"GB${eori.value}"
+    override def decode(s: String): GbEori = {
+      if (s.toUpperCase.startsWith("GB")) {
+        GbEori(s.drop(2))
+      } else {
+        throw new XmlDecodingException(s"Expected GB EORI did not start with GB: '$s'")
+      }
+    }
+  }
+
   implicit val bigDecimalFmt: StringFormat[BigDecimal] = StringFormat.simple(
     _.toString, BigDecimal(_)
   )

--- a/app/serialisation/xml/PartyFormats.scala
+++ b/app/serialisation/xml/PartyFormats.scala
@@ -17,7 +17,7 @@
 package serialisation.xml
 
 import scala.xml.{Elem, NodeSeq, Null, Text, TopScope}
-import models.{Address, Country}
+import models.{Address, Country, GbEori}
 import models.completion.Party
 import serialisation.xml.XmlImplicits._
 
@@ -42,7 +42,7 @@ trait PartyFormats extends CommonFormats {
 
     override def encode(p: Party): NodeSeq = p match {
       case Party.ByEori(eori) =>
-        elem(fields.eori, eori)
+        elem(fields.eori, eori.toXmlString)
       case Party.ByAddress(name, addr) =>
         Seq(
           elem(fields.name, name),
@@ -55,7 +55,7 @@ trait PartyFormats extends CommonFormats {
 
     override def decode(data: NodeSeq): Party = {
       (data \\ fields.eori).headOption map {
-        eori => Party.ByEori(eori.text)
+        eori => Party.ByEori(eori.text.parseXmlString[GbEori])
       } getOrElse {
         Party.ByAddress(
           (data \\ fields.name).text,

--- a/test-utils/generators/ModelGenerators.scala
+++ b/test-utils/generators/ModelGenerators.scala
@@ -391,10 +391,7 @@ trait ModelGenerators extends StringGenerators {
   }
 
   implicit lazy val arbitraryPartyByEori: Arbitrary[Party.ByEori] = Arbitrary {
-    for {
-      country <- Gen.oneOf(Country.allCountries)
-      number <- Gen.listOfN(12, Gen.numChar)
-    } yield Party.ByEori(s"${country.code}${number.mkString}")
+    arbitrary[GbEori].map(Party.ByEori)
   }
 
   implicit lazy val arbitraryPartyByAddress: Arbitrary[Party.ByAddress] = Arbitrary {

--- a/test/extractors/PartiesExtractorSpec.scala
+++ b/test/extractors/PartiesExtractorSpec.scala
@@ -50,7 +50,7 @@ class PartiesExtractorSpec extends SpecBase {
 
   private def tradersToParties(traders: List[Trader]): Map[Int, Party] = {
     traders.map {
-      case TraderWithEori(key, eori) => key -> Party.ByEori(eori)
+      case TraderWithEori(key, eori) => key -> Party.ByEori(GbEori(eori))
       case TraderWithoutEori(key, name, addr) => key -> Party.ByAddress(name, addr)
     }.toMap
   }

--- a/test/serialisation/xml/CommonFormatsSpec.scala
+++ b/test/serialisation/xml/CommonFormatsSpec.scala
@@ -20,7 +20,7 @@ import org.scalacheck.Arbitrary.arbitrary
 import org.scalatestplus.scalacheck.ScalaCheckPropertyChecks
 
 import base.SpecBase
-import models.{Country, LocalReferenceNumber}
+import models.{Country, GbEori, LocalReferenceNumber}
 
 class CommonFormatsSpec
   extends SpecBase
@@ -48,6 +48,20 @@ class CommonFormatsSpec
     "should work symmetrically" in {
       forAll(arbitrary[BigDecimal]) { bd =>
         bd.toXmlString.parseXmlString[BigDecimal] must be(bd)
+      }
+    }
+  }
+
+  "The GbEori format" - {
+    "should work symmetrically" in {
+      forAll(arbitrary[GbEori]) { eori =>
+        eori.toXmlString.parseXmlString[GbEori] must be(eori)
+      }
+    }
+
+    "should write with a GB prefix" in {
+      forAll(arbitrary[GbEori]) { eori =>
+        eori.toXmlString must be(s"GB${eori.value}")
       }
     }
   }

--- a/test/serialisation/xml/PartyFormatsSpec.scala
+++ b/test/serialisation/xml/PartyFormatsSpec.scala
@@ -20,7 +20,7 @@ import org.scalacheck.Arbitrary.arbitrary
 import org.scalacheck.Gen
 import org.scalatestplus.scalacheck.ScalaCheckPropertyChecks
 import base.SpecBase
-import models.{Address, Country}
+import models.{Address, GbEori}
 import models.completion.Party
 
 class PartyFormatsSpec
@@ -29,10 +29,7 @@ class PartyFormatsSpec
   with PartyFormats
   with XmlImplicits {
 
-  private val partyByEori: Gen[Party] = for {
-    country <- Gen.oneOf(Country.allCountries)
-    number <- Gen.listOfN(12, Gen.numChar)
-  } yield Party.ByEori(s"${country.code}${number.mkString}")
+  private val partyByEori: Gen[Party] = arbitrary[GbEori].map(Party.ByEori)
 
   private val partyByAddress: Gen[Party] = for {
     name <- stringsWithMaxLength(40)
@@ -50,7 +47,7 @@ class PartyFormatsSpec
       "should serialise correctly to XML" in {
         forAll(partyByEori) { p =>
           val actual = p.toXml
-          val expected = <TINCO259>{p.asInstanceOf[Party.ByEori].eori}</TINCO259>
+          val expected = <TINCO259>{p.asInstanceOf[Party.ByEori].eori.toXmlString}</TINCO259>
           actual must contain theSameElementsInOrderAs(expected)
         }
       }
@@ -91,7 +88,7 @@ class PartyFormatsSpec
       "should serialise correctly to XML" in {
         forAll(partyByEori) { p =>
           val actual = p.toXml
-          val expected = <TINCE259>{p.asInstanceOf[Party.ByEori].eori}</TINCE259>
+          val expected = <TINCE259>{p.asInstanceOf[Party.ByEori].eori.toXmlString}</TINCE259>
           actual must contain theSameElementsAs(expected)
         }
       }
@@ -132,7 +129,7 @@ class PartyFormatsSpec
       "should serialise correctly to XML" in {
         forAll(partyByEori) { p =>
           val actual = p.toXml
-          val expected = <TINPRTNOT641>{p.asInstanceOf[Party.ByEori].eori}</TINPRTNOT641>
+          val expected = <TINPRTNOT641>{p.asInstanceOf[Party.ByEori].eori.toXmlString}</TINPRTNOT641>
           actual must contain theSameElementsInOrderAs(expected)
         }
       }
@@ -173,7 +170,7 @@ class PartyFormatsSpec
       "should serialise correctly to XML" in {
         forAll(partyByEori) { p =>
           val actual = p.toXml
-          val expected = <TINPLD1>{p.asInstanceOf[Party.ByEori].eori}</TINPLD1>
+          val expected = <TINPLD1>{p.asInstanceOf[Party.ByEori].eori.toXmlString}</TINPLD1>
           actual must contain theSameElementsInOrderAs(expected)
         }
       }
@@ -214,7 +211,9 @@ class PartyFormatsSpec
       "should serialise correctly to XML" in {
         forAll(partyByEori) { p =>
           val actual = p.toXml
-          val expected = <TINTRACARENT602>{p.asInstanceOf[Party.ByEori].eori}</TINTRACARENT602>
+          val expected = {
+            <TINTRACARENT602>{p.asInstanceOf[Party.ByEori].eori.toXmlString}</TINTRACARENT602>
+          }
           actual must contain theSameElementsAs(expected)
         }
       }


### PR DESCRIPTION
We always identify a party by either GB EORI or by name + address; we
don't permit non-GB EORIs to be specified for any party.