### PR TITLE
SSUT-524: Consignor may be in top-level payload

### DIFF
--- a/app/models/completion/downstream/GoodsItem.scala
+++ b/app/models/completion/downstream/GoodsItem.scala
@@ -31,7 +31,7 @@ case class GoodsItem(
   placeOfLoading: LoadingPlace,
   placeOfUnloading: LoadingPlace,
   documents: List[Document],
-  consignor: Party,
+  consignor: Option[Party],
   consignee: Option[Party],
   notifiedParty: Option[Party],
   containers: List[Container],

--- a/app/models/completion/downstream/Submission.scala
+++ b/app/models/completion/downstream/Submission.scala
@@ -26,5 +26,6 @@ case class Submission(
   declarer: Party,
   seals: List[String],
   customsOffice: CustomsOffice,
-  carrier: Option[Party]
+  carrier: Option[Party],
+  consignor: Option[Party]
 )

--- a/app/serialisation/xml/GoodsItemFormats.scala
+++ b/app/serialisation/xml/GoodsItemFormats.scala
@@ -136,6 +136,10 @@ trait GoodsItemFormats
         sm => <SPEMENMT2>{sm.toXml}</SPEMENMT2>
       }
 
+      val consignor: NodeSeq = item.consignor.map { c =>
+        <TRACONCO2>{goodsConsignorFormat.encode(c)}</TRACONCO2>
+      }.toSeq
+
       val consignee: NodeSeq = item.consignee.map { c =>
         <TRACONCE2>{goodsConsigneeFormat.encode(c)}</TRACONCE2>
       }.toSeq
@@ -170,7 +174,7 @@ trait GoodsItemFormats
         <PlaUnlGOOITE333>{item.placeOfUnloading.toXmlString}</PlaUnlGOOITE333>,
         documents,
         specialMentions,
-        <TRACONCO2>{goodsConsignorFormat.encode(item.consignor)}</TRACONCO2>,
+        consignor,
         commCode,
         consignee,
         containers,
@@ -188,7 +192,7 @@ trait GoodsItemFormats
       placeOfLoading = (data \\ "PlaLoaGOOITE333").text.parseXmlString[LoadingPlace],
       placeOfUnloading = (data \\ "PlaUnlGOOITE333").text.parseXmlString[LoadingPlace],
       documents = (data \\ "PRODOCDC2").map { _.parseXml[Document] }.toList,
-      consignor = goodsConsignorFormat.decode(data \\ "TRACONCO2"),
+      consignor = (data \\ "TRACONCO2").headOption.map(goodsConsignorFormat.decode),
       consignee = (data \\ "TRACONCE2").headOption.map(goodsConsigneeFormat.decode),
       notifiedParty = (data \\ "PRTNOT640").headOption.map(goodsNotifiedPartyFormat.decode),
       containers = (data \\ "CONNR2").map { _.parseXml[Container] }.toList,

--- a/app/serialisation/xml/PartyFormats.scala
+++ b/app/serialisation/xml/PartyFormats.scala
@@ -107,6 +107,10 @@ trait PartyFormats extends CommonFormats {
       )
     )
   }
+
+  val rootConsignorFormat = {
+    partyFmt(Fields("TINCO159", "NamCO17", "StrAndNumCO122", "CitCO124", "PosCodCO123", "CouCO125"))
+  }
 }
 
 object PartyFormats extends PartyFormats {

--- a/app/serialisation/xml/SubmissionFormats.scala
+++ b/app/serialisation/xml/SubmissionFormats.scala
@@ -45,9 +45,14 @@ trait SubmissionFormats
         c => <TRACARENT601>{carrierFormat.encode(c)}</TRACARENT601>
       }.toSeq
 
+      val consignor = sub.consignor.map {
+        c => <TRACONCO1>{rootConsignorFormat.encode(c)}</TRACONCO1>
+      }.toSeq
+
       <ie:CC315A xmlns:ie="http://ics.dgtaxud.ec/CC315A">
         {sub.metadata.toXml}
         {sub.header.toXml}
+        {consignor}
         {goodsItems}
         {sub.itinerary.toXml}
         <PERLODSUMDEC>{lodgingPersonFormat.encode(sub.declarer)}</PERLODSUMDEC>
@@ -65,7 +70,8 @@ trait SubmissionFormats
       declarer = lodgingPersonFormat.decode(data \ "PERLODSUMDEC"),
       seals = (data \ "SEAID529" \ "SeaIdSEAID530").map { _.text }.toList,
       customsOffice = (data \ "CUSOFFFENT730").parseXml[CustomsOffice],
-      carrier = (data \ "TRACARENT601").headOption.map(carrierFormat.decode)
+      carrier = (data \ "TRACARENT601").headOption.map(carrierFormat.decode),
+      consignor = (data \ "TRACONCO1").headOption.map(rootConsignorFormat.decode),
     )
   }
 }

--- a/test-utils/generators/ModelGenerators.scala
+++ b/test-utils/generators/ModelGenerators.scala
@@ -150,6 +150,7 @@ trait ModelGenerators extends StringGenerators {
         seals <- Gen.listOfN(sealsLen, stringsWithMaxLength(20))
         customsOffice <- arbitrary[CustomsOfficePayload]
         carrier <- Gen.option(arbitrary[Party])
+        consignor <- Gen.option(arbitrary[Party])
       } yield {
         Submission(
           metadata,
@@ -159,7 +160,8 @@ trait ModelGenerators extends StringGenerators {
           declarer,
           seals,
           customsOffice,
-          carrier
+          carrier,
+          consignor
         )
       }
     }
@@ -429,7 +431,7 @@ trait ModelGenerators extends StringGenerators {
       placeOfUnloading <- arbitrary[LoadingPlace]
       documentsLen <- Gen.choose(0, 3)
       documents <- Gen.listOfN(documentsLen, arbitrary[Document])
-      consignor <- arbitrary[Party]
+      consignor <- Gen.option(arbitrary[Party])
       consignee <- Gen.option(arbitrary[Party])
       notifiedParty <- Gen.option(arbitrary[Party])
       containersLen <- Gen.choose(0, 3)

--- a/test/serialisation/xml/GoodsItemFormatsSpec.scala
+++ b/test/serialisation/xml/GoodsItemFormatsSpec.scala
@@ -196,6 +196,22 @@ class GoodsItemFormatsSpec extends SpecBase
         }
       }
 
+      "when consignor" - {
+        "is specified" in {
+          val gen = for {
+            item <- arbitrary[GoodsItem]
+            con <- arbitrary[Party]
+          } yield item.copy(consignor = Some(con))
+
+          forAll(gen) { item => item.toXml.parseXml[GoodsItem] must be(item) }
+        }
+
+        "is missing" in {
+          val gen = arbitrary[GoodsItem] map { _.copy(consignor = None) }
+          forAll(gen) { item => item.toXml.parseXml[GoodsItem] must be(item) }
+        }
+      }
+
       "when consignee" - {
         "is specified" in {
           val gen = for {

--- a/test/serialisation/xml/SubmissionFormatsSpec.scala
+++ b/test/serialisation/xml/SubmissionFormatsSpec.scala
@@ -53,6 +53,22 @@ class SubmissionFormatsSpec
         }
       }
 
+      "when consignor is" - {
+        "present" in {
+          val gen = for {
+            consignor <- arbitrary[Party]
+            submission <- arbitrary[Submission]
+          } yield submission.copy(consignor = Some(consignor))
+
+          forAll(gen) { item => item.toXml.parseXml[Submission] must be(item) }
+        }
+
+        "absent" in {
+          val gen = arbitrary[Submission] map { _.copy(consignor = None) }
+          forAll(gen) { item => item.toXml.parseXml[Submission] must be(item) }
+        }
+      }
+
       "when carrier is" - {
         "present" in {
           val gen = for {


### PR DESCRIPTION
If the consignor is the same for all goods items, we're obliged to
provide it at the top level fo the payload, and must not provide it in
the individual good items.

To facilitate this, add consignor as an optional field to the root
model, and change consignor to optional on the goods item model.