### PR TITLE
Fix automerge bug around Predec

### DIFF
--- a/app/extractors/TransportExtractor.scala
+++ b/app/extractors/TransportExtractor.scala
@@ -36,7 +36,6 @@ import cats.implicits._
 import models.completion.answers.Transport
 import models.{Country, Index, TransportIdentity, TransportMode, UserAnswers}
 import pages.transport._
-import queries._
 import queries.transport.{AllOverallDocumentsQuery, AllSealsQuery}
 
 class TransportExtractor(

--- a/test-utils/generators/ModelGenerators.scala
+++ b/test-utils/generators/ModelGenerators.scala
@@ -235,10 +235,10 @@ trait ModelGenerators extends StringGenerators {
       for {
         lrn <- arbitrary[LocalReferenceNumber]
         location <- stringsWithMaxLength(9)
+        carrier <- Gen.option(arbitrary[Party])
         totalMass <- Gen.option(grossMassGen)
-        carrierEORI <- Gen.option(arbitrary[GbEori])
       } yield {
-        Predec(lrn, location, totalMass, carrierEORI)
+        Predec(lrn, location, carrier, totalMass)
       }
     }
 


### PR DESCRIPTION
Looks like simultaneous to the Predec model and arbitrary Predec
generator by two separate commits resulted in a situation where git
automerged the history in a way which broke the build

This resulted in an apparently successful PR being merged and breaking
the main build.

This correctly fixes the conflict responsible.