### PR TITLE
SSUT-400: Adjust transport identity fields

### DIFF
--- a/app/models/completion/downstream/Header.scala
+++ b/app/models/completion/downstream/Header.scala
@@ -27,6 +27,5 @@ case class Header(
   itemCount: Int,
   packageCount: Int,
   grossMass: Option[BigDecimal],
-  conveyanceReferenceNumber: String,
   timePlace: DeclarationTimePlace
 )

--- a/app/models/completion/downstream/TransportDetails.scala
+++ b/app/models/completion/downstream/TransportDetails.scala
@@ -23,6 +23,7 @@ import models.{Country, TransportMode}
  */
 case class TransportDetails(
   mode: TransportMode,
-  identity: String,
-  nationality: Option[Country]
+  identity: Option[String],
+  nationality: Option[Country],
+  conveyanceReferenceNumber: Option[String]
 )

--- a/app/serialisation/xml/HeaderFormats.scala
+++ b/app/serialisation/xml/HeaderFormats.scala
@@ -34,8 +34,14 @@ trait HeaderFormats extends TransportFormats with TimeFormats {
 
       // Unfortunately we can't simply write using the TransportDetails format because we have to
       // position the individual fields in the right places across the header
+      val transportIdentity: NodeSeq = header.transportDetails.identity.map { id =>
+        <IdeOfMeaOfTraCroHEA85>{id}</IdeOfMeaOfTraCroHEA85>
+      }.toSeq
       val transportNationality: NodeSeq = header.transportDetails.nationality.map { n =>
         <NatOfMeaOfTraCroHEA87>{n.toXmlString}</NatOfMeaOfTraCroHEA87>
+      }.toSeq
+      val conveyanceRef: NodeSeq = header.transportDetails.conveyanceReferenceNumber.map { num =>
+        <ConRefNumHEA>{num}</ConRefNumHEA>
       }.toSeq
 
       val refNum: NodeSeq = header.ref match {
@@ -61,13 +67,13 @@ trait HeaderFormats extends TransportFormats with TimeFormats {
       <HEAHEA>
         {refNum}
         <TraModAtBorHEA76>{header.transportDetails.mode.toXmlString}</TraModAtBorHEA76>
-        <IdeOfMeaOfTraCroHEA85>{header.transportDetails.identity}</IdeOfMeaOfTraCroHEA85>
+        {transportIdentity}
         {transportNationality}
         <TotNumOfIteHEA305>{header.itemCount}</TotNumOfIteHEA305>
         <TotNumOfPacHEA306>{header.packageCount}</TotNumOfPacHEA306>
         {grossMass}
         {place}
-        <ConRefNumHEA>{header.conveyanceReferenceNumber}</ConRefNumHEA>
+        {conveyanceRef}
         {datetime}
       </HEAHEA>
     }
@@ -89,7 +95,6 @@ trait HeaderFormats extends TransportFormats with TimeFormats {
       itemCount = (data \ "TotNumOfIteHEA305").text.toInt,
       packageCount = (data \ "TotNumOfPacHEA306").text.toInt,
       grossMass = (data \ "TotGroMasHEA307").headOption map { _.text.parseXmlString[BigDecimal] },
-      conveyanceReferenceNumber = (data \ "ConRefNumHEA").text,
       timePlace = {
         ((data \ "DecPlaHEA394").headOption, (data \ "DecDatTimHEA114").headOption) match {
           case (Some(place), Some(dt)) =>

--- a/test-utils/generators/ModelGenerators.scala
+++ b/test-utils/generators/ModelGenerators.scala
@@ -321,9 +321,10 @@ trait ModelGenerators extends StringGenerators {
   implicit lazy val arbitraryTransportDetails: Arbitrary[TransportDetails] = Arbitrary {
     for {
       mode <- arbitrary[TransportMode]
-      identifier <- stringsWithMaxLength(27)
+      identifier <- Gen.option(stringsWithMaxLength(27))
       nationality <- Gen.option(arbitrary[Country])
-    } yield TransportDetails(mode, identifier, nationality)
+      conveyanceReferenceNumber <- Gen.option(stringsWithMaxLength(35))
+    } yield TransportDetails(mode, identifier, nationality, conveyanceReferenceNumber)
   }
 
   implicit lazy val arbitrarySubmissionTimePlace: Arbitrary[SubmissionTimePlace] = Arbitrary {
@@ -357,7 +358,6 @@ trait ModelGenerators extends StringGenerators {
       itemCount <- Gen.choose(1, 3)
       packageCount <- Gen.choose(1, 3)
       grossMass <- Gen.option(grossMassGen)
-      conveyanceReferenceNumber <- stringsWithMaxLength(35)
       timePlace <- arbitrary[SubmissionTimePlace]
     } yield {
       Header(
@@ -366,7 +366,6 @@ trait ModelGenerators extends StringGenerators {
         itemCount,
         packageCount,
         grossMass,
-        conveyanceReferenceNumber,
         timePlace
       )
     }

--- a/test/serialisation/xml/HeaderFormatsSpec.scala
+++ b/test/serialisation/xml/HeaderFormatsSpec.scala
@@ -29,39 +29,17 @@ class HeaderFormatsSpec
   with HeaderFormats
   with XmlImplicits {
 
-  private val headerGen: Gen[Header] = {
-    for {
-      lrn <- arbitrary[LocalReferenceNumber]
-      transportDetails <- arbitrary[TransportDetails]
-      itemCount <- Gen.choose(1, 3)
-      packageCount <- Gen.choose(1, 3)
-      grossMass <- Gen.option(Gen.choose(BigDecimal(0.001), BigDecimal(99999999.999)))
-      conveyanceReferenceNumber <- Gen.alphaNumStr
-      timePlace <- arbitrary[SubmissionTimePlace]
-    } yield {
-      Header(
-        lrn,
-        transportDetails,
-        itemCount,
-        packageCount,
-        grossMass,
-        conveyanceReferenceNumber,
-        timePlace
-      )
-    }
-  }
-
   "The header format" - {
     "should work symmetrically" - {
       "for any header with a SubmissionTimePlace" in {
-        forAll(headerGen) { h =>
+        forAll(arbitrary[Header]) { h =>
           h.toXml.parseXml[Header] must be(h)
         }
       }
 
       "for any header with a AmendmentTimePlace" in {
         val header = for {
-          header <- headerGen
+          header <- arbitrary[Header]
           atp <- arbitrary[AmendmentTimePlace]
         } yield header.copy(timePlace = atp)
 
@@ -73,7 +51,7 @@ class HeaderFormatsSpec
       "when gross mass" - {
         "is specified" in {
           val gen = for {
-            header <- headerGen
+            header <- arbitrary[Header]
             mass <- Gen.choose(1, 100000)
           } yield {
             header.copy(grossMass = Some(mass))
@@ -85,7 +63,7 @@ class HeaderFormatsSpec
         }
 
         "is missing" in {
-          val gen = headerGen map { _.copy(grossMass = None) }
+          val gen = arbitrary[Header] map { _.copy(grossMass = None) }
 
           forAll(gen) { h =>
             h.toXml.parseXml[Header] must be(h)


### PR DESCRIPTION
The fields "transport identity" and "conveyance reference number" are
both optional, as one or the other may be omitted depending on the mode
of transport, following some fairly complex business rules.

Conveyance reference number refers to air or maritime transport means,
so it more properly belongs in the TransportDetails section

Make these model changes and update the associated formats to continue
to format them the same way.

This is part 1 in the changes required to satisfy SSUT-400